### PR TITLE
bump core to 5.4.1

### DIFF
--- a/conan/conanfile.py
+++ b/conan/conanfile.py
@@ -11,7 +11,7 @@ class Pkg(ConanFile):
         "odrcore/*:with_wvWare": False,
         "odrcore/*:with_libmagic": False,
     }
-    requires = "odrcore/5.2.0"
+    requires = "odrcore/5.4.0"
 
     def generate(self):
         xcode = XcodeDeps(self)

--- a/conan/conanfile.py
+++ b/conan/conanfile.py
@@ -11,7 +11,7 @@ class Pkg(ConanFile):
         "odrcore/*:with_wvWare": False,
         "odrcore/*:with_libmagic": False,
     }
-    requires = "odrcore/5.4.0"
+    requires = "odrcore/5.4.1"
 
     def generate(self):
         xcode = XcodeDeps(self)

--- a/conan/conanfile.py
+++ b/conan/conanfile.py
@@ -10,6 +10,7 @@ class Pkg(ConanFile):
         "odrcore/*:with_pdf2htmlEX": False,
         "odrcore/*:with_wvWare": False,
         "odrcore/*:with_libmagic": False,
+        "odrcore/*:with_http_server": False,
     }
     requires = "odrcore/5.4.1"
 


### PR DESCRIPTION
Bumps `odrcore` to 5.4.1 in `conan/conanfile.py`.

## odrcore 5.4.1 ([release notes](https://github.com/opendocument-app/OpenDocument.core/releases/tag/v5.4.1))
- **Relicense from GPL-3.0 to MPL-2.0** ([#597](https://github.com/opendocument-app/OpenDocument.core/pull/597))
- Guard empty asset data paths; default `ODR_BUNDLE_ASSETS` to OFF ([#600](https://github.com/opendocument-app/OpenDocument.core/pull/600))
- Make the HTTP server optional via `ODR_WITH_HTTP_SERVER` ([#601](https://github.com/opendocument-app/OpenDocument.core/pull/601))

The preceding 5.4.0 release ([notes](https://github.com/opendocument-app/OpenDocument.core/releases/tag/v5.4.0)) landed the large native PDF rendering pipeline (text extraction, embedded/substituted fonts, vector graphics, images, shadings, transparency), plus initial `.ppt`/`.xls` support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
