### PR TITLE
Get recipes from conan-odr-index instead of our artifactory

### DIFF
--- a/.github/workflows/ios_main.yml
+++ b/.github/workflows/ios_main.yml
@@ -18,9 +18,13 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
 
+      - name: checkout conan-odr-index
+        run: git submodule update --init --depth 1 conan-odr-index
+
+      # 3.12+ is required by the conan-odr-index helper scripts
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.12"
 
       - uses: maxim-lobanov/setup-xcode@v1
         with:
@@ -35,16 +39,17 @@ jobs:
       - name: install fastlane
         run: bundle install
 
+      # conan itself is pinned by conan-odr-index so recipes and client stay in sync
       - name: install conan
-        run: pip3 install conan
+        run: pip3 install -r conan-odr-index/requirements.txt
 
-      - name: conan remote
-        run: |
-          conan remote remove "*"
-          conan remote add odr https://artifactory.opendocument.app/artifactory/api/conan/conan
-          conan remote add conancenter https://center2.conan.io
       - name: conan profile
         run: conan profile detect
+
+      # recipes are exported from the submodule into the local cache, which is
+      # why no private remote has to be configured
+      - name: export conan-odr-index
+        run: python3 conan-odr-index/scripts/conan_export_all_packages.py
 
       - name: conan install
         run: >
@@ -54,9 +59,7 @@ jobs:
           --profile:host=conan/profiles/ios-simulator-arm64
           --deployer=conan/conandeployer.py
           --deployer-folder=conan-assets
-          -s build_type=Release
-          -s "&:build_type=RelWithDebInfo"
-          -s "odrcore/*:build_type=RelWithDebInfo"
+          -o "configuration=Debug"
 
       - name: run tests
         run: bundle exec fastlane tests

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "conan-odr-index"]
+	path = conan-odr-index
+	url = https://github.com/opendocument-app/conan-odr-index.git

--- a/OpenDocumentReader.xcodeproj/project.pbxproj
+++ b/OpenDocumentReader.xcodeproj/project.pbxproj
@@ -7,11 +7,13 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		49F8B3EC1E30DF3C043B89E9 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = B94897965C815527C6C06996 /* PrivacyInfo.xcprivacy */; };
 		523A371328CCF27400876C77 /* AdServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 523A371228CCF27400876C77 /* AdServices.framework */; };
 		523A371528CCF28100876C77 /* StoreKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 523A371428CCF28100876C77 /* StoreKit.framework */; };
 		523A371728CCF28900876C77 /* AppTrackingTransparency.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 523A371628CCF28900876C77 /* AppTrackingTransparency.framework */; };
 		52A348B42A92635E00DACAB9 /* Pods_OpenDocumentReader.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 52A348B32A92635E00DACAB9 /* Pods_OpenDocumentReader.framework */; };
 		52DE0FAF45FE38FFAE9E4910 /* Pods_OpenDocumentReaderTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 559CD8DFE3C657DEB311030B /* Pods_OpenDocumentReaderTests.framework */; };
+		7C4296FE8B2389E12E7687F7 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = B01C1B2BA00A7917FF7D7726 /* PrivacyInfo.xcprivacy */; };
 		AC125F162435311A008AD515 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = AC125F182435311A008AD515 /* Localizable.strings */; };
 		AC384BCD23B4FFA700C7BF47 /* ContentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC384BC923B4FFA700C7BF47 /* ContentViewController.swift */; };
 		AC384BCE23B4FFA700C7BF47 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC384BCA23B4FFA700C7BF47 /* Constants.swift */; };
@@ -87,7 +89,9 @@
 		ACD9BE2D2444A371009014E6 /* ConfigurationManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConfigurationManager.swift; sourceTree = "<group>"; };
 		ACF1A3E22469EFB5000BA420 /* GoogleService-Info-Lite.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info-Lite.plist"; sourceTree = "<group>"; };
 		ACF1A3E42469F8DE000BA420 /* Info-Lite.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Info-Lite.plist"; sourceTree = "<group>"; };
+		B01C1B2BA00A7917FF7D7726 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		B3FCFC99F5757D71C0A3EB11 /* Pods-OpenDocumentReader.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OpenDocumentReader.debug.xcconfig"; path = "Pods/Target Support Files/Pods-OpenDocumentReader/Pods-OpenDocumentReader.debug.xcconfig"; sourceTree = "<group>"; };
+		B94897965C815527C6C06996 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		C39C76F36758805489D19A8D /* Pods-OpenDocumentReader.debug lite.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OpenDocumentReader.debug lite.xcconfig"; path = "Pods/Target Support Files/Pods-OpenDocumentReader/Pods-OpenDocumentReader.debug lite.xcconfig"; sourceTree = "<group>"; };
 		D7F1C22195A1CA95F6A6DEF4 /* Pods-OpenDocumentReaderTests.debug lite.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OpenDocumentReaderTests.debug lite.xcconfig"; path = "Pods/Target Support Files/Pods-OpenDocumentReaderTests/Pods-OpenDocumentReaderTests.debug lite.xcconfig"; sourceTree = "<group>"; };
 		DF0AB0A593247807A3F41DFA /* Pods_OpenDocumentReader.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_OpenDocumentReader.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -142,6 +146,34 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		3FF7388D538126B646A5ACC6 /* Privacy */ = {
+			isa = PBXGroup;
+			children = (
+				D14366468BE2F636C9CEF33C /* Full */,
+				9DB359255AA99AA16B2336F4 /* Lite */,
+			);
+			name = Privacy;
+			path = Privacy;
+			sourceTree = "<group>";
+		};
+		9DB359255AA99AA16B2336F4 /* Lite */ = {
+			isa = PBXGroup;
+			children = (
+				B94897965C815527C6C06996 /* PrivacyInfo.xcprivacy */,
+			);
+			name = Lite;
+			path = Lite;
+			sourceTree = "<group>";
+		};
+		D14366468BE2F636C9CEF33C /* Full */ = {
+			isa = PBXGroup;
+			children = (
+				B01C1B2BA00A7917FF7D7726 /* PrivacyInfo.xcprivacy */,
+			);
+			name = Full;
+			path = Full;
+			sourceTree = "<group>";
+		};
 		E17AF34D2C258C5100FBED6A /* configs */ = {
 			isa = PBXGroup;
 			children = (
@@ -233,6 +265,7 @@
 				E2C008FC220F1D570097C594 /* CoreWrapper.h */,
 				E2D0B3D8226D945400534FCC /* StoreReviewHelper.swift */,
 				AC125F182435311A008AD515 /* Localizable.strings */,
+				3FF7388D538126B646A5ACC6 /* Privacy */,
 			);
 			path = OpenDocumentReader;
 			sourceTree = "<group>";
@@ -355,6 +388,8 @@
 				E22EB71C226B66B300053B86 /* Main.storyboard in Resources */,
 				E29E4077225A4672002C06E6 /* GoogleService-Info.plist in Resources */,
 				E2F7ED5E220B54D700D63515 /* Assets.xcassets in Resources */,
+				7C4296FE8B2389E12E7687F7 /* PrivacyInfo.xcprivacy in Resources */,
+				49F8B3EC1E30DF3C043B89E9 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -633,6 +668,7 @@
 				ENABLE_BITCODE = NO;
 				ENABLE_MODULE_VERIFIER = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
+				EXCLUDED_SOURCE_FILE_NAMES = "OpenDocumentReader/Privacy/Full/*";
 				INFOPLIST_FILE = "OpenDocumentReader/Info-Lite.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "OpenDocument Reader";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
@@ -727,6 +763,7 @@
 				ENABLE_BITCODE = NO;
 				ENABLE_MODULE_VERIFIER = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
+				EXCLUDED_SOURCE_FILE_NAMES = "OpenDocumentReader/Privacy/Full/*";
 				INFOPLIST_FILE = "OpenDocumentReader/Info-Lite.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "OpenDocument Reader";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
@@ -965,6 +1002,7 @@
 				ENABLE_BITCODE = NO;
 				ENABLE_MODULE_VERIFIER = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
+				EXCLUDED_SOURCE_FILE_NAMES = "OpenDocumentReader/Privacy/Lite/*";
 				INFOPLIST_FILE = OpenDocumentReader/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "OpenDocument Reader";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
@@ -1002,6 +1040,7 @@
 				ENABLE_BITCODE = NO;
 				ENABLE_MODULE_VERIFIER = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
+				EXCLUDED_SOURCE_FILE_NAMES = "OpenDocumentReader/Privacy/Lite/*";
 				INFOPLIST_FILE = OpenDocumentReader/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "OpenDocument Reader";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";

--- a/OpenDocumentReader/Info-Lite.plist
+++ b/OpenDocumentReader/Info-Lite.plist
@@ -62,7 +62,7 @@
 	<string>Main</string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
-		<string>armv7</string>
+		<string>arm64</string>
 	</array>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>

--- a/OpenDocumentReader/Info.plist
+++ b/OpenDocumentReader/Info.plist
@@ -68,7 +68,7 @@
 	<string>Main</string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
-		<string>armv7</string>
+		<string>arm64</string>
 	</array>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>

--- a/OpenDocumentReader/Privacy/Full/PrivacyInfo.xcprivacy
+++ b/OpenDocumentReader/Privacy/Full/PrivacyInfo.xcprivacy
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/OpenDocumentReader/Privacy/Lite/PrivacyInfo.xcprivacy
+++ b/OpenDocumentReader/Privacy/Lite/PrivacyInfo.xcprivacy
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<true/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# OpenDocument.ios ![](https://github.com/TomTasche/OpenDocument.ios/workflows/build/badge.svg)
+# OpenDocument.ios ![](https://github.com/opendocument-app/OpenDocument.ios/actions/workflows/ios_main.yml/badge.svg)
 It's Android's first OpenOffice Document Reader... for iOS!
 
 ## Setup

--- a/README.md
+++ b/README.md
@@ -1,7 +1,22 @@
 # OpenDocument.ios ![](https://github.com/opendocument-app/OpenDocument.ios/actions/workflows/ios_main.yml/badge.svg)
 It's Android's first OpenOffice Document Reader... for iOS!
 
+This is an iOS frontend for our C++ [OpenDocument.core](https://github.com/opendocument-app/OpenDocument.core) library.
+
 ## Setup
-1. run "pod install"
-2. run "conan/setup-all.sh"
-3. open workspace in Xcode
+
+Our C++ dependencies come from [conan-odr-index](https://github.com/opendocument-app/conan-odr-index),
+which is checked out as a submodule and exported into the local conan cache. No
+private conan remote is involved.
+
+1. install conan into a venv: `pip install -r conan-odr-index/requirements.txt`
+2. `conan profile detect`
+3. `git submodule update --init --depth 1 conan-odr-index`
+4. `pod install`
+5. `conan/setup-all.sh` — exports the recipes and generates the xcconfigs for
+   every configuration and architecture. The first run builds odrcore and its
+   dependencies from source and takes a while.
+6. open `OpenDocumentReader.xcworkspace` in Xcode
+
+`conan/setup-all.sh` has to be re-run whenever the odrcore version in
+`conan/conanfile.py` or the `conan-odr-index` submodule changes.

--- a/conan/profiles/ios
+++ b/conan/profiles/ios
@@ -1,13 +1,5 @@
-include(default)
+include(ios-base)
 
 [settings]
-os=iOS
 os.sdk=iphoneos
-os.version=14.0
 arch=armv8
-
-compiler.cppstd=20
-
-&:build_type=RelWithDebInfo
-odrcore/*:build_type=RelWithDebInfo
-build_type=Release

--- a/conan/profiles/ios-base
+++ b/conan/profiles/ios-base
@@ -1,0 +1,12 @@
+include(default)
+
+[settings]
+os=iOS
+os.version=14.0
+
+compiler.cppstd=20
+
+# dependencies are plain release builds, odrcore keeps debug info so crash
+# reports from the field stay symbolicatable
+build_type=Release
+odrcore/*:build_type=RelWithDebInfo

--- a/conan/profiles/ios-simulator-arm64
+++ b/conan/profiles/ios-simulator-arm64
@@ -1,13 +1,5 @@
-include(default)
+include(ios-base)
 
 [settings]
-os=iOS
 os.sdk=iphonesimulator
-os.version=14.0
 arch=armv8
-
-compiler.cppstd=20
-
-&:build_type=RelWithDebInfo
-odrcore/*:build_type=RelWithDebInfo
-build_type=Release

--- a/conan/profiles/ios-simulator-x64
+++ b/conan/profiles/ios-simulator-x64
@@ -1,13 +1,5 @@
-include(default)
+include(ios-base)
 
 [settings]
-os=iOS
 os.sdk=iphonesimulator
-os.version=14.0
 arch=x86_64
-
-compiler.cppstd=20
-
-&:build_type=RelWithDebInfo
-odrcore/*:build_type=RelWithDebInfo
-build_type=Release

--- a/conan/setup-all.sh
+++ b/conan/setup-all.sh
@@ -1,43 +1,53 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 # https://stackoverflow.com/a/246128/198996
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-cd $DIR/..
+cd "$DIR/.."
 
-# assets
-conan install conan/ \
-  --output-folder=conan-output \
-  --build=missing \
-  --profile:host=conan/profiles/ios \
-  --deployer=conan/conandeployer.py \
-  --deployer-folder=conan-assets \
-  -s build_type=Release \
-  -s "&:build_type=Release" \
-  -s "odrcore/*:build_type=RelWithDebInfo" \
-  -o "configuration=Release"
+CONFIGURATIONS=("Debug" "Debug Lite" "Release" "Release Lite")
 
-# device
-for configuration in "Debug" "Debug Lite" "Release" "Release Lite"; do
+if [ ! -f conan-odr-index/scripts/conan_export_all_packages.py ]; then
+  echo "conan-odr-index submodule is missing. Run:" >&2
+  echo "  git submodule update --init --depth 1 conan-odr-index" >&2
+  exit 1
+fi
+
+# our recipes live in the conan-odr-index submodule and get exported into the
+# local cache, so no private remote is involved
+python3 conan-odr-index/scripts/conan_export_all_packages.py
+
+# XcodeDeps appends to the per-package include lists rather than rewriting them,
+# so leftovers from earlier runs keep shadowing freshly generated files
+rm -rf conan-output conan-assets
+
+install() {
+  local profile="$1"
+  local configuration="$2"
+  shift 2
+
   conan install conan/ \
     --output-folder=conan-output \
     --build=missing \
-    --profile:host=conan/profiles/ios \
-    -s build_type=Release \
-    -s "&:build_type=Release" \
-    -s "odrcore/*:build_type=RelWithDebInfo" \
-    -o "configuration=${configuration}"
+    --profile:host="conan/profiles/${profile}" \
+    -o "configuration=${configuration}" \
+    "$@"
+}
+
+# assets, deployed into the app bundle as odrcore's runtime data
+install ios "Release" \
+  --deployer=conan/conandeployer.py \
+  --deployer-folder=conan-assets
+
+# device
+for configuration in "${CONFIGURATIONS[@]}"; do
+  install ios "${configuration}"
 done
 
 # simulator
 for arch in "arm64" "x64"; do
-  for configuration in "Debug" "Debug Lite" "Release" "Release Lite"; do
-    conan install conan/ \
-      --output-folder=conan-output \
-      --build=missing \
-      --profile:host=conan/profiles/ios-simulator-${arch} \
-      -s build_type=Release \
-      -s "&:build_type=Release" \
-      -s "odrcore/*:build_type=RelWithDebInfo" \
-      -o "configuration=${configuration}"
+  for configuration in "${CONFIGURATIONS[@]}"; do
+    install "ios-simulator-${arch}" "${configuration}"
   done
 done

--- a/upload-symbols.sh
+++ b/upload-symbols.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-Pods/FirebaseCrashlytics/upload-symbols -gsp OpenDocumentReader/GoogleService-Info.plist -p ios ~/Downloads/appDsyms.zip
-Pods/FirebaseCrashlytics/upload-symbols -gsp OpenDocumentReader/GoogleService-Info.plist -p ios ~/Downloads/appDsyms\ \(1\).zip
-
-Pods/FirebaseCrashlytics/upload-symbols -gsp OpenDocumentReader/GoogleService-Info-Lite.plist -p ios ~/Downloads/appDsyms.zip
-Pods/FirebaseCrashlytics/upload-symbols -gsp OpenDocumentReader/GoogleService-Info-Lite.plist -p ios ~/Downloads/appDsyms\ \(1\).zip


### PR DESCRIPTION
Stacked on #107.

Mirrors what OpenDocument.droid did in its `kill-artifactory` work: `conan-odr-index` becomes a submodule whose recipes are exported into the local conan cache, so neither CI nor a fresh clone touches `artifactory.opendocument.app`. The submodule is pinned to `49780d8`, the same commit droid currently uses (odrcore 5.5.0).

## Changes

**Artifactory removal**
- `conan-odr-index` added as a submodule (the previously empty `.gitmodules` now has content).
- CI drops `conan remote remove "*"` / `conan remote add odr https://artifactory.opendocument.app/...` and instead runs `conan_export_all_packages.py`.
- CI installs conan from `conan-odr-index/requirements.txt` so client and recipes stay in sync.
- CI python goes 3.10 → 3.12: the index helper scripts use PEP 701 f-strings, which are a `SyntaxError` before 3.12.

**Stale generated output bug (found while testing)**
`setup-all.sh` now wipes `conan-output`/`conan-assets` before regenerating. `XcodeDeps` *appends* to the per-package include lists rather than rewriting them, so an xcconfig generated by an older conan (`conan_odrcore_odrcore_debug lite_...`, with a space) survives alongside the new one (`..._debug_lite_...`, with an underscore) and, being included later, wins — while pointing at a package folder that no longer exists. On this checkout that made every Lite configuration fail with `'odr/document.hpp' file not found`.

**Profile deduplication**
The three profiles were identical apart from `os.sdk`/`arch`; the shared part moved to `ios-base`. They already carried the `build_type` settings that every `conan install` call then repeated, and local and CI disagreed about `&:build_type` (`Release` vs `RelWithDebInfo`). The consumer conanfile produces no binaries, so that setting only changed the filenames of conan env helper scripts that nothing in this repo sources.

## Verification

- Generated `conan-output` before and after the profile/flag change: **byte-identical** for all four configurations.
- Old CI flags vs new CI flags: all `.xcconfig` files identical; only the unused `conanbuildenv-*`/`conanrunenv-*` helper script names differ.
- `ODR Full` (Debug) builds green against the regenerated output.
- `conan_export_all_packages.py` runs in ~7s and resolves everything with only `conancenter` configured — no artifactory remote present locally.