### PR TITLE
Give the odrcore wrapper typed errors and stop crashing on purpose

### DIFF
--- a/OpenDocumentReader/AppDelegate.swift
+++ b/OpenDocumentReader/AppDelegate.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-@UIApplicationMain
+@main
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
@@ -50,8 +50,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ app: UIApplication, open inputURL: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
         guard let documentBrowserViewController = window?.rootViewController as? DocumentBrowserViewController else {
-            fatalError("documentBrowserViewController is null")
-            
+            CrashManager.shared.log("root view controller is not a DocumentBrowserViewController")
+
             return false
         }
         
@@ -66,8 +66,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 try FileManager.default.moveItem(at: inputURL, to: destinationUrl)
             } catch {
                 CrashManager.shared.log(error)
-                fatalError("copying from Inbox failed")
-                
+
                 return false
             }
         } else {

--- a/OpenDocumentReader/Constants.swift
+++ b/OpenDocumentReader/Constants.swift
@@ -8,20 +8,8 @@
 
 import Foundation
 
-class Constants {
-    static let start = "Start"
-    static let skip = "Skip"
-    static let next = "Next"
-    static let onboarding_header_1 = "Open and read your ODF file on the go!"
-    static let onboarding_header_2 = "Found a typo in your document? Now supports modification!"
-    static let onboarding_header_3 = "Read your documents from within other apps"
-    static let onboarding_subheader_1 = "OpenDocument Reader allows you to view documents that are stored in OpenDocument format (.odt, .ods, .odp and .odg). These files are usually created using LibreOffice or OpenOffice. This app allows to open such files on your mobile device too, so you can read them on the go."
-    static let onboarding_subheader_2 = "OpenDocument Reader not only allows to read documents on your mobile device, but also supports modifying them too. Typos are fixed in a breeze, even on the train!"
-    static let onboarding_subheader_3 = "OpenDocument Reader supports a huge range of other apps to open documents from. A colleague sent a presentation via Gmail? Click the attachment and this app is going to open right away!"
-    static let onboarding_image_1 = "onboard1"
-    static let onboarding_image_2 = "onboard2"
-    static let onboarding_image_3 = "onboard3"
+enum Constants {
+    static let onboardingImages = ["onboard1", "onboard2", "onboard3"]
+
     static let key_was_intro_watched = "wasIntroWatched"
-    static let configurationFull = "Full"
-    static let configurationLite = "Lite"
 }

--- a/OpenDocumentReader/ContentViewController.swift
+++ b/OpenDocumentReader/ContentViewController.swift
@@ -32,30 +32,23 @@ class ContentViewController: UIViewController {
             pageControl.pageIndicatorTintColor = #colorLiteral(red: 0.8039215803, green: 0.8039215803, blue: 0.8039215803, alpha: 1)
         }
         
-        switch index {
-        case 0:
-            pageButton.setTitle(Constants.next, for: .normal)
-        case 1:
-            pageButton.setTitle(Constants.next, for: .normal)
-        case 2:
-            pageButton.setTitle(Constants.start, for: .normal)
-        default:
-            break
-        }
+        let isLastPage = index == Constants.onboardingImages.count - 1
+        pageButton.setTitle(
+            NSLocalizedString(isLastPage ? "intro_start" : "intro_next", comment: ""),
+            for: .normal)
         
         headerLabel.text = header
         subHeaderLabel.text = subHeader
         imageView.image = UIImage(named: imageFile)
         pageControl.currentPage = index
-        pageControl.numberOfPages = 3
+        pageControl.numberOfPages = Constants.onboardingImages.count
     }
     
 
     @IBAction func pageButtonPressed(_ sender: Any) {
         switch index {
-        case 0,1:
-            let pageVC = parent as! PageViewController
-            pageVC.nextVC(atIndex: index)
+        case 0, 1:
+            (parent as? PageViewController)?.nextVC(atIndex: index)
         case 2:
             dismissViewController()
         default:
@@ -68,10 +61,8 @@ class ContentViewController: UIViewController {
     }
     
     func dismissViewController() {
-        let userDefaults = UserDefaults.standard
-        userDefaults.setValue(true, forKey: Constants.key_was_intro_watched)
-        userDefaults.synchronize()
-        
+        UserDefaults.standard.set(true, forKey: Constants.key_was_intro_watched)
+
         dismiss(animated: true, completion: nil)
     }
     

--- a/OpenDocumentReader/ContentViewController.swift
+++ b/OpenDocumentReader/ContentViewController.swift
@@ -33,8 +33,14 @@ class ContentViewController: UIViewController {
         }
         
         let isLastPage = index == Constants.onboardingImages.count - 1
+        // only en.lproj carries these keys so far, and a missing key resolves to
+        // the key itself rather than to the development language. The explicit
+        // value keeps the other 16 localizations on the English wording the
+        // button hardcoded before instead of showing "intro_next".
         pageButton.setTitle(
-            NSLocalizedString(isLastPage ? "intro_start" : "intro_next", comment: ""),
+            isLastPage
+                ? NSLocalizedString("intro_start", value: "Start", comment: "onboarding button on the last page")
+                : NSLocalizedString("intro_next", value: "Next", comment: "onboarding button advancing to the next page"),
             for: .normal)
         
         headerLabel.text = header

--- a/OpenDocumentReader/CoreWrapper.h
+++ b/OpenDocumentReader/CoreWrapper.h
@@ -11,14 +11,37 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
+extern NSErrorDomain const CoreWrapperErrorDomain;
+
+typedef NS_ERROR_ENUM(CoreWrapperErrorDomain, CoreWrapperError) {
+    /// odrcore threw something we have no specific handling for.
+    CoreWrapperErrorUnknown = 1,
+    /// The document is encrypted and the supplied password did not open it.
+    CoreWrapperErrorWrongPassword = 2,
+    /// Not a document odrcore can translate. PDFs land here on purpose.
+    CoreWrapperErrorUnsupportedFileType = 3,
+};
+
 @interface CoreWrapper : NSObject
 
-@property NSArray *pageNames;
-@property NSArray *pagePaths;
-@property NSNumber *errorCode;
+@property (nonatomic, copy, readonly) NSArray<NSString *> *pageNames;
+@property (nonatomic, copy, readonly) NSArray<NSString *> *pagePaths;
 
-- (bool)translate:(NSString *)inputPath cache:(NSString *)cachePath into:(NSString *)outputPath with:(NSString *)password editable:(bool)editable;
-- (bool)backTranslate:(NSString *)diff into:(NSString *)outputPath;
+- (BOOL)translate:(NSString *)inputPath
+            cache:(NSString *)cachePath
+             into:(NSString *)outputPath
+             with:(nullable NSString *)password
+         editable:(BOOL)editable
+            error:(NSError **)error;
+
+- (BOOL)backTranslate:(NSString *)diff
+                 into:(NSString *)outputPath
+                error:(NSError **)error;
+
 @end
+
+NS_ASSUME_NONNULL_END
 
 #endif /* CoreWrapper_h */

--- a/OpenDocumentReader/CoreWrapper.mm
+++ b/OpenDocumentReader/CoreWrapper.mm
@@ -1,5 +1,5 @@
 //
-//  CoreWrapper.m
+//  CoreWrapper.mm
 //  OpenDocument Reader
 //
 //  Created by Thomas Taschauer on 09.02.19.
@@ -18,126 +18,195 @@
 #include <odr/exceptions.hpp>
 #include <odr/global_params.hpp>
 
-#include <string>
+#include <algorithm>
 #include <optional>
-#include <iostream>
+#include <string>
 
-@implementation CoreWrapper {
-    std::optional<odr::Document> document;
-    std::optional<odr::Html> html;
+NSErrorDomain const CoreWrapperErrorDomain = @"app.opendocument.CoreWrapperErrorDomain";
+
+static NSError *CoreWrapperMakeError(CoreWrapperError code, NSString *description) {
+    return [NSError errorWithDomain:CoreWrapperErrorDomain
+                               code:code
+                           userInfo:@{NSLocalizedDescriptionKey: description}];
 }
 
-- (bool)translate:(NSString *)inputPath cache:(NSString *)cachePath into:(NSString *)outputPath with:(NSString *)password editable:(bool)editable {
+/// odrcore's data files ship inside the app bundle. The path never changes at
+/// runtime, so it is set once instead of on every translate call.
+static void CoreWrapperEnsureDataPath() {
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        NSString *bundlePath = [[NSBundle mainBundle] bundlePath];
+        std::string dataPath = std::string([bundlePath UTF8String]) + "/odrcore";
+        odr::GlobalParams::set_odr_core_data_path(dataPath);
+    });
+}
+
+@implementation CoreWrapper {
+    std::optional<odr::Document> _document;
+    std::optional<odr::Html> _html;
+}
+
+- (BOOL)translate:(NSString *)inputPath
+            cache:(NSString *)cachePath
+             into:(NSString *)outputPath
+             with:(NSString *)password
+         editable:(BOOL)editable
+            error:(NSError **)error {
     @synchronized(self) {
+        _pageNames = nil;
+        _pagePaths = nil;
+
         try {
-            _errorCode = 0;
-            _pageNames = nil;
-            _pagePaths = nil;
+            CoreWrapperEnsureDataPath();
 
-            NSString *bundlePath = [[NSBundle mainBundle] bundlePath];
-            std::string bundlePathCpp = std::string([bundlePath UTF8String]);
-            odr::GlobalParams::set_odr_core_data_path(bundlePathCpp + "/odrcore");
-
-            html.reset();
+            _html.reset();
 
             odr::HtmlConfig config;
             config.editable = editable;
 
-            if (password == nil) {
-                password = @"";
-            }
-
-            auto inputPathC = [inputPath UTF8String];
-            auto inputPathCpp = std::string(inputPathC);
+            std::string inputPathCpp = std::string([inputPath UTF8String]);
 
             std::vector<odr::FileType> fileTypes;
             try {
                 fileTypes = odr::list_file_types(inputPathCpp);
-                if (fileTypes.empty()) {
-                    _errorCode = @(-5);
-                    return false;
+            } catch (odr::UnsupportedFileType &) {
+                fileTypes.clear();
+            }
+            if (fileTypes.empty()) {
+                if (error) {
+                    *error = CoreWrapperMakeError(CoreWrapperErrorUnsupportedFileType,
+                                                  @"odrcore does not recognise this file type");
                 }
-            } catch (odr::UnsupportedFileType &e) {
-                _errorCode = @(-5);
-                return false;
+                return NO;
             }
 
-            if (std::find(fileTypes.begin(), fileTypes.end(), odr::FileType::portable_document_format) != fileTypes.end()) {
-                _errorCode = @(-5);
-                return false;
+            // PDFs are handed to WKWebView instead, which renders them natively
+            if (std::find(fileTypes.begin(), fileTypes.end(),
+                          odr::FileType::portable_document_format) != fileTypes.end()) {
+                if (error) {
+                    *error = CoreWrapperMakeError(CoreWrapperErrorUnsupportedFileType,
+                                                  @"PDF is rendered by the web view, not by odrcore");
+                }
+                return NO;
             }
 
-            auto outputPathC = [outputPath UTF8String];
-            auto outputPathCpp = std::string(outputPathC);
-
-            auto cachePathC = [cachePath UTF8String];
-            auto cachePathCpp = std::string(cachePathC);
+            std::string outputPathCpp = std::string([outputPath UTF8String]);
+            std::string cachePathCpp = std::string([cachePath UTF8String]);
 
             odr::DecodedFile file = odr::open(inputPathCpp);
             if (file.password_encrypted()) {
+                std::string passwordCpp = password != nil ? std::string([password UTF8String]) : std::string();
                 try {
-                    file = file.decrypt(std::string([password UTF8String]));
+                    file = file.decrypt(passwordCpp);
                 } catch (odr::WrongPasswordError &) {
-                    _errorCode = @(-2);
-                    return false;
+                    if (error) {
+                        *error = CoreWrapperMakeError(CoreWrapperErrorWrongPassword,
+                                                      @"wrong password");
+                    }
+                    return NO;
                 }
             }
+
             if (!file.is_document_file()) {
-                _errorCode = @(-5);
-                return false;
+                if (error) {
+                    *error = CoreWrapperMakeError(CoreWrapperErrorUnsupportedFileType,
+                                                  @"not a document file");
+                }
+                return NO;
             }
-            document = file.as_document_file().document();
 
-            html = odr::html::translate(*document, cachePathCpp, config).bring_offline(outputPathCpp);
+            odr::DocumentFile documentFile = file.as_document_file();
+            odr::DocumentType documentType = documentFile.document_type();
+            _document = documentFile.document();
 
-            NSMutableArray *pageNames = [[NSMutableArray alloc] init];
-            NSMutableArray *pagePaths = [[NSMutableArray alloc] init];
-            for (const auto &page : html->pages()) {
-                if (file.is_document_file() && (
-                        (((file.as_document_file().document_type() == odr::DocumentType::presentation) ||
-                          (file.as_document_file().document_type() == odr::DocumentType::drawing)) &&
-                         (page.name != "document")) ||
-                        ((file.as_document_file().document_type() == odr::DocumentType::spreadsheet) &&
-                         (page.name == "document")))) {
+            _html = odr::html::translate(*_document, cachePathCpp, config).bring_offline(outputPathCpp);
+
+            NSMutableArray<NSString *> *pageNames = [[NSMutableArray alloc] init];
+            NSMutableArray<NSString *> *pagePaths = [[NSMutableArray alloc] init];
+            for (const auto &page : _html->pages()) {
+                if ([self shouldSkipPageNamed:page.name ofDocumentType:documentType]) {
                     continue;
                 }
 
-                [pageNames addObject:[NSString stringWithCString:page.name.c_str() encoding:[NSString defaultCStringEncoding]]];
-                [pagePaths addObject:[NSString stringWithCString:page.path.c_str() encoding:[NSString defaultCStringEncoding]]];
+                [pageNames addObject:[NSString stringWithUTF8String:page.name.c_str()]];
+                [pagePaths addObject:[NSString stringWithUTF8String:page.path.c_str()]];
+            }
+
+            if (pagePaths.count == 0) {
+                if (error) {
+                    *error = CoreWrapperMakeError(CoreWrapperErrorUnknown,
+                                                  @"odrcore produced no displayable page");
+                }
+                return NO;
             }
 
             _pageNames = pageNames;
             _pagePaths = pagePaths;
-        } catch (odr::UnknownFileType&) {
-            _errorCode = @(-5);
-            return false;
-        } catch (std::runtime_error &e) {
-            std::cout << e.what() << std::endl;
-            _errorCode = @(-3);
-            return false;
-        } catch (...) {
-            _errorCode = @(-3);
-            return false;
-        }
 
-        return true;
+            return YES;
+        } catch (odr::UnknownFileType &) {
+            if (error) {
+                *error = CoreWrapperMakeError(CoreWrapperErrorUnsupportedFileType,
+                                              @"unknown file type");
+            }
+            return NO;
+        } catch (std::exception &e) {
+            if (error) {
+                *error = CoreWrapperMakeError(CoreWrapperErrorUnknown,
+                                              [NSString stringWithUTF8String:e.what()]);
+            }
+            return NO;
+        } catch (...) {
+            if (error) {
+                *error = CoreWrapperMakeError(CoreWrapperErrorUnknown, @"unknown failure in odrcore");
+            }
+            return NO;
+        }
     }
 }
 
-- (bool)backTranslate:(NSString *)diff into:(NSString *)outputPath {
+/// Presentations and drawings expose their slides as pages and a combined
+/// "document" page we do not want; spreadsheets are the other way round.
+- (BOOL)shouldSkipPageNamed:(const std::string &)name ofDocumentType:(odr::DocumentType)documentType {
+    bool isCombinedPage = name == "document";
+
+    if (documentType == odr::DocumentType::presentation ||
+        documentType == odr::DocumentType::drawing) {
+        return isCombinedPage ? NO : YES;
+    }
+    if (documentType == odr::DocumentType::spreadsheet) {
+        return isCombinedPage ? YES : NO;
+    }
+    return NO;
+}
+
+- (BOOL)backTranslate:(NSString *)diff into:(NSString *)outputPath error:(NSError **)error {
     @synchronized(self) {
-        try {
-            _errorCode = 0;
-
-            odr::html::edit(*document, [diff UTF8String]);
-
-            document->save([outputPath UTF8String]);
-        } catch (...) {
-            _errorCode = @(-3);
-            return false;
+        if (!_document.has_value()) {
+            if (error) {
+                *error = CoreWrapperMakeError(CoreWrapperErrorUnknown,
+                                              @"no document has been translated yet");
+            }
+            return NO;
         }
-        
-        return true;
+
+        try {
+            odr::html::edit(*_document, [diff UTF8String]);
+            _document->save([outputPath UTF8String]);
+
+            return YES;
+        } catch (std::exception &e) {
+            if (error) {
+                *error = CoreWrapperMakeError(CoreWrapperErrorUnknown,
+                                              [NSString stringWithUTF8String:e.what()]);
+            }
+            return NO;
+        } catch (...) {
+            if (error) {
+                *error = CoreWrapperMakeError(CoreWrapperErrorUnknown, @"unknown failure in odrcore");
+            }
+            return NO;
+        }
     }
 }
 

--- a/OpenDocumentReader/Document.swift
+++ b/OpenDocumentReader/Document.swift
@@ -1,10 +1,10 @@
 import UIKit
 import WebKit
 
-protocol DocumentDelegate: class {
+protocol DocumentDelegate: AnyObject {
     func documentUpdateContent(_ doc: Document)
     func documentEncrypted(_ doc: Document)
-    func documentLoadingError(_ doc: Document, errorCode: Int)
+    func documentLoadingError(_ doc: Document, error: Error)
     func documentLoadingStarted(_ doc: Document)
     func documentLoadingCompleted(_ doc: Document)
     func documentPagesChanged(_ doc: Document)
@@ -15,19 +15,17 @@ enum DocumentError: Error {
     case backTranslate
 }
 
-
 class Document: UIDocument {
-    
+
     public var result: URL?
     public var pageNames: [String]?
     public var pagePaths: [String]?
 
     public weak var delegate: DocumentDelegate?
     public var loadProgress = Progress(totalUnitCount: 5)
-    
-    private var saveGroup = DispatchGroup()
+
     private var coreWrapper = CoreWrapper()
-    
+
     public var page: Int = 0 {
         didSet {
             parse()
@@ -43,127 +41,146 @@ class Document: UIDocument {
             parse()
         }
     }
-    
+
     public var webview: WKWebView?
-    
+
     public var isOdf = false
     private var wasPageCountAnnounced = false
-    
+
     override init(fileURL url: URL) {
         super.init(fileURL: url)
     }
-    
+
     override func load(fromContents contents: Any, ofType typeName: String?) throws {
         parse()
     }
-    
+
     func parse() {
         delegate?.documentLoadingStarted(self)
-        
+
         loadProgress.completedUnitCount = 2
-        loadProgress.resume()
-        
+
         result = nil
         delegate?.documentUpdateContent(self)
 
         let cachePath = URL(fileURLWithPath: NSTemporaryDirectory())
         let outputPath = URL(fileURLWithPath: NSTemporaryDirectory())
-        coreWrapper.translate(fileURL.path, cache: cachePath.path, into: outputPath.path, with: password, editable: edit)
 
-        let errorCode = coreWrapper.errorCode != nil ? coreWrapper.errorCode.intValue : 0
-        if (errorCode == -2) {
-            self.delegate?.documentEncrypted(self)
-            
+        do {
+            try coreWrapper.translate(
+                fileURL.path,
+                cache: cachePath.path,
+                into: outputPath.path,
+                with: password,
+                editable: edit
+            )
+        } catch let error as NSError
+            where error.domain == CoreWrapperErrorDomain
+                && error.code == CoreWrapperError.wrongPassword.rawValue {
+            delegate?.documentEncrypted(self)
+
+            return
+        } catch {
+            delegate?.documentLoadingError(self, error: error)
+
             return
         }
-        
-        if (errorCode < 0) {
-            delegate?.documentLoadingError(self, errorCode: errorCode)
-            
-            return
-        }
-        
+
         isOdf = true
-        
+
         loadProgress.completedUnitCount = loadProgress.totalUnitCount
-        
-        var pageNames = [String]()
-        for object in coreWrapper.pageNames {
-            if let pageName = object as? String {
-                pageNames.append(pageName)
-            }
-        }
-        
-        var pagePaths = [String]()
-        for object in coreWrapper.pagePaths {
-            if let pagePath = object as? String {
-                pagePaths.append(pagePath)
-            }
-        }
-        
+
+        // translate only reports success once it has at least one page
+        let pagePaths = coreWrapper.pagePaths
+        let pageNames = coreWrapper.pageNames
         self.pagePaths = pagePaths
         self.pageNames = pageNames
-        
+
         // TODO: use all pages instead of just one!
-        result = URL(fileURLWithPath: pagePaths[page])
-        
+        result = URL(fileURLWithPath: pagePaths[min(page, pagePaths.count - 1)])
+
         delegate?.documentUpdateContent(self)
-        
-        if (!wasPageCountAnnounced) {
+
+        if !wasPageCountAnnounced {
             delegate?.documentPagesChanged(self)
-            
+
             wasPageCountAnnounced = true
         }
-        
+
         delegate?.documentLoadingCompleted(self)
     }
-    
+
     override func handleError(_ error: Error, userInteractionPermitted: Bool) {
         CrashManager.shared.log(error)
     }
-    
+
     override func writeContents(_ contents: Any, to url: URL, for saveOperation: UIDocument.SaveOperation, originalContentsURL: URL?) throws {
-        var diff = ""
+        let diff = try generateDiff()
 
-        DispatchQueue.main.sync {
-            self.saveGroup.enter()
+        // CoreWrapper is guarded by @synchronized, but the document handle it
+        // holds is only valid together with the web view that produced the diff,
+        // so the call stays on the main thread
+        try onMainThread {
+            try coreWrapper.backTranslate(diff, into: url.path)
+        }
+    }
 
-            webview?.evaluateJavaScript("odr.generateDiff()", completionHandler: { (value: Any!, error: Error!) -> Void in
-                if error != nil {
+    /// UIDocument calls writeContents off the main thread, but hopping to main
+    /// unconditionally would deadlock if that ever changes.
+    private func onMainThread<T>(_ work: () throws -> T) rethrows -> T {
+        if Thread.isMainThread {
+            return try work()
+        }
+
+        return try DispatchQueue.main.sync(execute: work)
+    }
+
+    /// Asks the web view for the edits the user made. Runs on the main thread
+    /// and blocks the calling save thread until the JavaScript call comes back.
+    private func generateDiff() throws -> String {
+        let semaphore = DispatchSemaphore(value: 0)
+        var result: Result<String, Error> = .failure(DocumentError.getHtml)
+
+        DispatchQueue.main.async {
+            guard let webview = self.webview else {
+                result = .failure(DocumentError.getHtml)
+                semaphore.signal()
+
+                return
+            }
+
+            webview.evaluateJavaScript("odr.generateDiff()") { value, error in
+                // signalled on every path, including the ones that used to leave
+                // the dispatch group unbalanced and fall into the 30s timeout
+                defer { semaphore.signal() }
+
+                if let error {
                     CrashManager.shared.log(error)
-                    fatalError("generateDiff failed")
+                    result = .failure(error)
 
                     return
                 }
-                
-                diff = (value as? String)!
 
-                self.saveGroup.leave()
-            })
+                guard let diff = value as? String else {
+                    result = .failure(DocumentError.getHtml)
+
+                    return
+                }
+
+                result = .success(diff)
+            }
         }
-        
-        let waitResult = saveGroup.wait(timeout: .now() + 30)
-        if (waitResult != DispatchTimeoutResult.success) {
+
+        guard semaphore.wait(timeout: .now() + 30) == .success else {
             throw DocumentError.getHtml
         }
-        
-        // running on main-thread to make sure CoreWrapper is always called from the same thread
-        // TODO: run on background thread instead?
-        DispatchQueue.main.sync {
-            coreWrapper.backTranslate(diff, into: url.path)
-        }
-        
-        let errorCode = coreWrapper.errorCode != nil ? coreWrapper.errorCode.intValue : 0
-        if (errorCode < 0) {
-            print(errorCode)
-            
-            throw DocumentError.backTranslate
-        }
+
+        return try result.get()
     }
 }
 
 extension Document {
-    
+
     var shortenedDocumentUrl: String {
         return fileURL.absoluteString.prefix(49) + ".." + fileURL.absoluteString.suffix(49)
     }

--- a/OpenDocumentReader/DocumentBrowserViewController.swift
+++ b/OpenDocumentReader/DocumentBrowserViewController.swift
@@ -37,35 +37,35 @@ class DocumentBrowserViewController: UIDocumentBrowserViewController, UIDocument
     }
     
     func documentBrowser(_ controller: UIDocumentBrowserViewController, didImportDocumentAt sourceURL: URL, toDestinationURL destinationURL: URL) {
-        print("==> Imported A Document from %@ to %@.")
-        
         presentDocument(at: destinationURL)
     }
     
     func documentBrowser(_ controller: UIDocumentBrowserViewController, failedToImportDocumentAt documentURL: URL, error: Error?) {
+        if let error {
+            CrashManager.shared.log(error)
+        }
+
+        showGenericError()
+    }
+
+    private func showGenericError() {
         let alert = UIAlertController(
             title: "",
             message: NSLocalizedString("toast_error_generic", comment: ""),
             preferredStyle: .alert)
-        
-        let action = UIAlertAction(
+
+        alert.addAction(UIAlertAction(
             title: NSLocalizedString("ok", comment: ""),
             style: .cancel,
-            handler: nil)
-        
-        alert.addAction(action)
-        
-        controller.present(alert, animated: true, completion: nil)
+            handler: nil))
+
+        present(alert, animated: true, completion: nil)
     }
     
     func documentBrowser(_ controller: UIDocumentBrowserViewController,
                          didPickDocumentURLs documentURLs: [URL]) {
-        guard let url = documentURLs.first else {
-            fatalError("documentURL is null")
+        guard let url = documentURLs.first else { return }
 
-            return
-        }
-        
         presentDocument(at: url)
     }
     
@@ -78,8 +78,12 @@ class DocumentBrowserViewController: UIDocumentBrowserViewController, UIDocument
             presentedViewController?.dismiss(animated: false, completion: nil)
         }
         
-        let tempController = storyBoard.instantiateViewController(withIdentifier: "TextDocumentViewController")
-        let documentViewController = tempController as! DocumentViewController
+        guard let documentViewController = storyBoard
+            .instantiateViewController(withIdentifier: "TextDocumentViewController") as? DocumentViewController else {
+            CrashManager.shared.log("TextDocumentViewController missing from Main.storyboard")
+
+            return
+        }
         documentController = documentViewController
         
         documentViewController.modalPresentationCapturesStatusBarAppearance = true
@@ -99,16 +103,18 @@ class DocumentBrowserViewController: UIDocumentBrowserViewController, UIDocument
             AnalyticsConstants.paramItemName: shortenedDocumentUrl
         ])
         
-        doc.open { [weak self](success) in
+        doc.open { [weak self] success in
             transitionController.loadingProgress = nil
-            
+
+            guard let self else { return }
             guard success else {
-                fatalError("opening document failed")
+                CrashManager.shared.log("opening \(doc.shortenedDocumentUrl) failed")
+                self.showGenericError()
 
                 return
             }
-            
-            self?.present(documentViewController, animated: true, completion: nil)
+
+            self.present(documentViewController, animated: true, completion: nil)
         }
     }
 }

--- a/OpenDocumentReader/DocumentViewController.swift
+++ b/OpenDocumentReader/DocumentViewController.swift
@@ -161,7 +161,9 @@ class DocumentViewController: UIViewController, DocumentDelegate, BannerViewDele
     func showWebsite() {
         AnalyticsManager.shared.report("menu_help")
         
-        UIApplication.shared.openURL(URL(string: "https://opendocument.app")!)
+        guard let url = URL(string: "https://opendocument.app") else { return }
+
+        UIApplication.shared.open(url)
     }
     
     func toggleFullscreen() {
@@ -234,11 +236,11 @@ class DocumentViewController: UIViewController, DocumentDelegate, BannerViewDele
     
     @IBAction func returnToDocuments(_ sender: Any) {
         guard let doc = document else {
-            fatalError("document is null")
+            closeCurrentDocument()
 
             return
         }
-        
+
         if doc.edit {
             let alert = UIAlertController(title: NSLocalizedString("alert_unsaved_changes", comment: ""), message: NSLocalizedString("alert_save_now", comment: ""), preferredStyle: .alert)
             alert.addAction(UIAlertAction(title: NSLocalizedString("no", comment: ""), style: .destructive, handler: { (_) in
@@ -266,13 +268,7 @@ class DocumentViewController: UIViewController, DocumentDelegate, BannerViewDele
     }
     
     func closeCurrentDocument() {
-        guard let doc = document else {
-            fatalError("document is null")
-
-            return
-        }
-        
-        doc.close()
+        document?.close()
         self.dismiss(animated: true, completion: nil)
     }
     
@@ -313,24 +309,18 @@ class DocumentViewController: UIViewController, DocumentDelegate, BannerViewDele
     func discardChanges() {
         AnalyticsManager.shared.report("menu_edit_discard")
 
-        guard let doc = document else {
-            fatalError("document is null")
-
-            return
-        }
-        
-        doc.edit = true
+        document?.edit = true
     }
     
     func saveContent(completion: ((Bool) -> ())?) {
         AnalyticsManager.shared.report("menu_edit_save")
 
         guard let doc = document else {
-            fatalError("document is null")
+            completion?(false)
 
             return
         }
-        
+
         doc.save(to: doc.fileURL, for: .forOverwriting) { success in
             let message: String
             let color: UIColor
@@ -403,12 +393,15 @@ class DocumentViewController: UIViewController, DocumentDelegate, BannerViewDele
     func documentEncrypted(_ doc: Document) {
 //        self.webview.loadHTMLString("<html><h1>Error</h1>Failed to load given document because it is encrypted. Feel free to contact us via tomtasche@gmail.com for further questions.</html>", baseURL: nil)
         
-        if (viewIfLoaded?.window == nil) {
+        if viewIfLoaded?.window == nil {
             // delay because ViewController might not be visible yet
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1, execute: {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
                 self.documentEncrypted(doc)
-            })
+            }
+
+            return
         }
+
         
         let alert = UIAlertController(title: NSLocalizedString("toast_error_password_protected", comment: ""), message: "", preferredStyle: .alert)
         alert.addTextField { (textField) in
@@ -418,15 +411,13 @@ class DocumentViewController: UIViewController, DocumentDelegate, BannerViewDele
             self.returnToDocuments("nil" as Any)
         }))
         alert.addAction(UIAlertAction(title: NSLocalizedString("ok", comment: ""), style: .default, handler: { [weak alert] (_) in
-            let textField = alert?.textFields![0]
-            
-            self.document?.password = textField!.text!
+            self.document?.password = alert?.textFields?.first?.text ?? ""
         }))
         
         self.present(alert, animated: true, completion: nil)
     }
     
-    func documentLoadingError(_ doc: Document, errorCode: Int) {
+    func documentLoadingError(_ doc: Document, error: Error) {
         // attention: wrong for extensions like ".pages.zip"
         let fileType = doc.fileURL.pathExtension.lowercased()
         
@@ -454,7 +445,7 @@ class DocumentViewController: UIViewController, DocumentDelegate, BannerViewDele
         AnalyticsManager.shared.report(
             "load_error",
             parameters: [
-                "code": errorCode,
+                "code": (error as NSError).code,
                 AnalyticsConstants.paramItemName: doc.shortenedDocumentUrl,
                 AnalyticsConstants.paramContentType: fileType
             ])
@@ -462,7 +453,7 @@ class DocumentViewController: UIViewController, DocumentDelegate, BannerViewDele
     
     func documentLoadingStarted(_ doc: Document) {
         progressBar.isHidden = false
-        progressBar.observedProgress = doc.progress
+        progressBar.observedProgress = doc.loadProgress
     }
     
     func documentLoadingCompleted(_ doc: Document) {

--- a/OpenDocumentReader/PageViewController.swift
+++ b/OpenDocumentReader/PageViewController.swift
@@ -18,9 +18,7 @@ class PageViewController: UIPageViewController {
     var subHeadersArray = [NSLocalizedString("intro_description_open", comment: ""),
                            NSLocalizedString("intro_description_edit", comment: ""),
                            NSLocalizedString("intro_description_apps", comment: ""),]
-    var imagesArray = [Constants.onboarding_image_1,
-                       Constants.onboarding_image_2,
-                       Constants.onboarding_image_3]
+    var imagesArray = Constants.onboardingImages
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -54,16 +52,14 @@ class PageViewController: UIPageViewController {
 
 extension PageViewController: UIPageViewControllerDataSource {
     func pageViewController(_ pageViewController: UIPageViewController, viewControllerBefore viewController: UIViewController) -> UIViewController? {
-        var index = (viewController as! ContentViewController).index
-        index -= 1
+        guard let index = (viewController as? ContentViewController)?.index else { return nil }
 
-        return displayViewController(at: index)
+        return displayViewController(at: index - 1)
     }
     
     func pageViewController(_ pageViewController: UIPageViewController, viewControllerAfter viewController: UIViewController) -> UIViewController? {
-        var index = (viewController as! ContentViewController).index
-        index += 1
+        guard let index = (viewController as? ContentViewController)?.index else { return nil }
 
-        return displayViewController(at: index)
+        return displayViewController(at: index + 1)
     }
 }

--- a/OpenDocumentReader/en.lproj/Localizable.strings
+++ b/OpenDocumentReader/en.lproj/Localizable.strings
@@ -72,3 +72,8 @@
 
 /*  */
 "error" = "Error";
+
+/* Onboarding buttons. Were hardcoded English in Constants.swift before. */
+"intro_next" = "Next";
+"intro_skip" = "Skip";
+"intro_start" = "Start";

--- a/OpenDocumentReaderTests/OpenDocumentReaderTests.swift
+++ b/OpenDocumentReaderTests/OpenDocumentReaderTests.swift
@@ -11,58 +11,96 @@ import XCTest
 @testable import OpenDocumentReader
 
 class OpenDocumentReaderTests: XCTestCase {
-    // ONLINE fails on GitHub Actions for some reason
-    private let ONLINE = false
-
-    private var saveURL: URL?
+    private var saveURL: URL!
 
     override func setUpWithError() throws {
-        var fileURL: URL?
-
-        let documentsURL = try
-            FileManager.default.url(for: .documentDirectory,
-                                    in: .userDomainMask,
-                                    appropriateFor: nil,
-                                    create: false)
+        let documentsURL = try FileManager.default.url(
+            for: .documentDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: false)
 
         saveURL = documentsURL.appendingPathComponent("test.odt")
 
-        if (FileManager.default.fileExists(atPath: saveURL!.path)) {
-            return
+        if FileManager.default.fileExists(atPath: saveURL.path) {
+            try FileManager.default.removeItem(at: saveURL)
         }
 
-        if (ONLINE) {
-            let url = URL(string: "https://api.libreoffice.org/examples/cpp/DocumentLoader/test.odt")
-            
-            let downloadTask = URLSession.shared.downloadTask(with: url!) {
-                urlOrNil, responseOrNil, errorOrNil in fileURL = urlOrNil
-            }
-            downloadTask.resume()
-        } else {
-            let filePath = Bundle(for: type(of: self)).path(forResource: "test", ofType: "odt")
-            fileURL = URL(fileURLWithPath: filePath!)
-        }
-
-        try FileManager.default.copyItem(at: fileURL!, to: self.saveURL!)
+        let bundlePath = try XCTUnwrap(
+            Bundle(for: type(of: self)).path(forResource: "test", ofType: "odt"))
+        try FileManager.default.copyItem(at: URL(fileURLWithPath: bundlePath), to: saveURL)
     }
 
-    func testExample() throws {
+    private func makeWrapper() -> (wrapper: CoreWrapper, cache: String, output: String) {
+        let temporaryDirectory = NSTemporaryDirectory()
+
+        return (CoreWrapper(), temporaryDirectory, temporaryDirectory)
+    }
+
+    func testTranslatesDocumentIntoPages() throws {
+        let (wrapper, cache, output) = makeWrapper()
+
+        try wrapper.translate(saveURL.path, cache: cache, into: output, with: nil, editable: true)
+
+        XCTAssertFalse(wrapper.pagePaths.isEmpty)
+        XCTAssertEqual(wrapper.pagePaths.count, wrapper.pageNames.count)
+        for path in wrapper.pagePaths {
+            XCTAssertTrue(FileManager.default.fileExists(atPath: path), "missing page at \(path)")
+        }
+    }
+
+    func testBackTranslateWritesEditedDocument() throws {
+        let (wrapper, cache, output) = makeWrapper()
+
+        try wrapper.translate(saveURL.path, cache: cache, into: output, with: nil, editable: true)
+
+        let editedURL = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("test-edited.odt")
+        try? FileManager.default.removeItem(at: editedURL)
+
+        let diff = """
+            {"modifiedText":{"/child:3/child:0":"This is a simple test document to demonstrate the DocumentLoaderwwww example!"}}
+            """
+
+        try wrapper.backTranslate(diff, into: editedURL.path)
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: editedURL.path))
+    }
+
+    /// backTranslate used to dereference an empty std::optional when nothing had
+    /// been translated yet.
+    func testBackTranslateWithoutTranslateFails() {
+        let (wrapper, _, _) = makeWrapper()
+
+        let editedURL = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("never-translated.odt")
+
+        XCTAssertThrowsError(try wrapper.backTranslate("{}", into: editedURL.path)) { error in
+            XCTAssertEqual((error as NSError).domain, CoreWrapperErrorDomain)
+        }
+    }
+
+    func testUnsupportedFileTypeReportsTypedError() throws {
+        let (wrapper, cache, output) = makeWrapper()
+
+        let notADocument = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("not-a-document.odt")
+        try "definitely not an office document".write(to: notADocument, atomically: true, encoding: .utf8)
+
+        XCTAssertThrowsError(
+            try wrapper.translate(notADocument.path, cache: cache, into: output, with: nil, editable: false)
+        ) { error in
+            let error = error as NSError
+            XCTAssertEqual(error.domain, CoreWrapperErrorDomain)
+            XCTAssertEqual(error.code, CoreWrapperError.unsupportedFileType.rawValue)
+        }
+    }
+
+    func testTranslatePerformance() throws {
+        let (wrapper, cache, output) = makeWrapper()
+
         measure {
-            let coreWrapper = CoreWrapper()
-
-            let cachePath = URL(fileURLWithPath: NSTemporaryDirectory())
-            let outputPath = URL(fileURLWithPath: NSTemporaryDirectory())
-
-            coreWrapper.translate(saveURL?.path, cache: cachePath.path, into: outputPath.path, with: nil, editable: true)
-            XCTAssertNil(coreWrapper.errorCode)
-
-            var backTranslatePath = URL(fileURLWithPath: NSTemporaryDirectory())
-            backTranslatePath.appendPathComponent("test-edited.odt")
-
-            let diff = "{\"modifiedText\":{\"/child:3/child:0\":\"This is a simple test document to demonstrate the DocumentLoaderwwww example!\"}}"
-
-            coreWrapper.backTranslate(diff, into: backTranslatePath.path)
-            XCTAssertNil(coreWrapper.errorCode)
+            try? wrapper.translate(saveURL.path, cache: cache, into: output, with: nil, editable: true)
         }
     }
 }


### PR DESCRIPTION
Stacked on #113.

`CoreWrapper` reported failures through an `NSNumber errorCode` carrying `-2`, `-3` and `-5`, decoded again in `Document.swift` and a third time in `DocumentViewController`. It also assigned `0` to an object pointer to mean success, so `XCTAssertNil(coreWrapper.errorCode)` was passing for the wrong reason. It now uses an `NSErrorDomain` + `NS_ERROR_ENUM`, which Swift imports as throwing methods.

## Crashes fixed

- **`pagePaths[page]` unchecked.** The page filter drops every page for some document shapes (a spreadsheet whose only page is named `document`), so an empty array was reachable and indexing it killed the app. `translate` now fails with an error rather than reporting success with nothing to show, and the index is clamped.
- **`backTranslate` dereferenced an empty `std::optional`** when called before any `translate`. Now a typed error — covered by a new test.
- **`writeContents` leaked its DispatchGroup.** `enter()` happened inside the JS completion handler and `leave()` only on the happy path, so a failing `generateDiff` left it unbalanced and every save burned the full 30s timeout before throwing. It also called `fatalError` from that handler. Replaced with a semaphore signalled on every path, plus a main-thread guard so hopping to main can't deadlock.
- **Eight `fatalError` calls used as error handling**, for states users actually reach: no document, failed import, missing storyboard identifier, root controller of an unexpected type. Each now recovers or reports.
- Three `as!` casts on storyboard lookups, and the password alert's `textFields![0]` / `.text!`.
- `documentEncrypted` rescheduled itself when the view wasn't in a window yet — and then presented the alert anyway.

## Other cleanups

- `DocumentDelegate: class` → `AnyObject`
- `@UIApplicationMain` → `@main`
- `UIApplication.shared.openURL` → `open(_:)` (deprecated since iOS 10)
- `UserDefaults.synchronize()` (no-op since iOS 12)
- The progress bar observed `UIDocument.progress`, not the `loadProgress` that `parse()` actually advances — so it never moved.
- The onboarding buttons were hardcoded English in `Constants` while the app ships 17 localizations. Now `NSLocalizedString` with `intro_next`/`intro_skip`/`intro_start` added to `en.lproj`; other languages fall back to English exactly as they do today, but are now translatable via Crowdin. The rest of `Constants` was dead code.

## Verification

- Both flavors build; both install and launch in a simulator and stay running.
- Test suite goes from **1 test** (a `measure` block asserting a nil error code) to **5**, all passing: page output, back translation, `backTranslate` before `translate`, unsupported file type, and the performance measurement.

## Deliberately not in this PR

The `actor` + `async/await` restructure of `CoreWrapper`. `parse()` still runs the C++ translate synchronously on whatever thread the `didSet` fired on. That change alters threading semantics, and with no integration coverage over document loading I would be changing behavior I cannot verify. It wants its own PR with tests written first — say the word and I will do it next.