### PR TITLE
Adopt the UIScene life cycle

### DIFF
--- a/OpenDocumentReader.xcodeproj/project.pbxproj
+++ b/OpenDocumentReader.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		229BA8DA70F3CA88BA547FA9 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4579E708F099784EF583B35 /* SceneDelegate.swift */; };
 		32B6BA42C6D6D443ED2A9697 /* AnalyticsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DF2708F60BE3388B124CABF /* AnalyticsManager.swift */; };
 		49F8B3EC1E30DF3C043B89E9 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = B94897965C815527C6C06996 /* PrivacyInfo.xcprivacy */; };
 		523A371328CCF27400876C77 /* AdServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 523A371228CCF27400876C77 /* AdServices.framework */; };
@@ -84,6 +85,7 @@
 		ACF1A3E42469F8DE000BA420 /* Info-Lite.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Info-Lite.plist"; sourceTree = "<group>"; };
 		B01C1B2BA00A7917FF7D7726 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		B94897965C815527C6C06996 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		C4579E708F099784EF583B35 /* SceneDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		D14280D860FAA1DD046BCB5C /* conan.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = conan.xcconfig; sourceTree = "<group>"; };
 		E1EB6C492C1A510D003EC5A0 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		E2064DDF22CFA1BA006441F8 /* iAd.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = iAd.framework; path = System/Library/Frameworks/iAd.framework; sourceTree = SDKROOT; };
@@ -260,6 +262,7 @@
 				3FF7388D538126B646A5ACC6 /* Privacy */,
 				9113B590877803CA250DDFB7 /* NonFree */,
 				7CA823F10FA4C2CBDA62F8D8 /* Vendor */,
+				C4579E708F099784EF583B35 /* SceneDelegate.swift */,
 			);
 			path = OpenDocumentReader;
 			sourceTree = "<group>";
@@ -439,6 +442,7 @@
 				32B6BA42C6D6D443ED2A9697 /* AnalyticsManager.swift in Sources */,
 				BFFB694BE9E3E744FD4F92E0 /* CrashManager.swift in Sources */,
 				FF3C583F3A1EDECDBE3F267F /* ScrollableSegmentedControl.swift in Sources */,
+				229BA8DA70F3CA88BA547FA9 /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/OpenDocumentReader/AppDelegate.swift
+++ b/OpenDocumentReader/AppDelegate.swift
@@ -11,10 +11,7 @@ import UIKit
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
-    var window: UIWindow?
-
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        
         // same split OpenDocument.droid uses: reporting only in the ad
         // supported flavor, nothing at all in the paid one
         let reportingEnabled = ConfigurationManager.manager.configuration == .lite
@@ -22,69 +19,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         CrashManager.shared.setEnabled(reportingEnabled)
 
         StoreReviewHelper.incrementAppOpenedCount()
-        
-        return true
-    }
-
-    func applicationWillResignActive(_ application: UIApplication) {
-        // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
-        // Use this method to pause ongoing tasks, disable timers, and invalidate graphics rendering callbacks. Games should use this method to pause the game.
-    }
-
-    func applicationDidEnterBackground(_ application: UIApplication) {
-        // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
-        // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
-    }
-
-    func applicationWillEnterForeground(_ application: UIApplication) {
-        // Called as part of the transition from the background to the active state; here you can undo many of the changes made on entering the background.
-    }
-
-    func applicationDidBecomeActive(_ application: UIApplication) {
-        // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
-    }
-
-    func applicationWillTerminate(_ application: UIApplication) {
-        // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
-    }
-
-    func application(_ app: UIApplication, open inputURL: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
-        guard let documentBrowserViewController = window?.rootViewController as? DocumentBrowserViewController else {
-            CrashManager.shared.log("root view controller is not a DocumentBrowserViewController")
-
-            return false
-        }
-        
-        let documentsUrl = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
-        let inboxUrl = documentsUrl.appendingPathComponent("Inbox")
-
-        let destinationUrl: URL
-        if (inputURL.absoluteString.contains(inboxUrl.absoluteString)) {
-            do {
-                destinationUrl = documentsUrl.appendingPathComponent(inputURL.lastPathComponent)
-
-                try FileManager.default.moveItem(at: inputURL, to: destinationUrl)
-            } catch {
-                CrashManager.shared.log(error)
-
-                return false
-            }
-        } else {
-            destinationUrl = inputURL
-        }
-        
-        documentBrowserViewController.revealDocument(at: destinationUrl, importIfNeeded: true) { (revealedDocumentURL, error) in
-            guard let documentUrl = revealedDocumentURL else {
-                // ignoring errors because they should pop up in failedToImportDocumentAt too
-                
-                return;
-            }
-            
-            documentBrowserViewController.presentDocument(at: documentUrl)
-        }
 
         return true
     }
-    
+
+    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+    }
 }
-

--- a/OpenDocumentReader/Info-Lite.plist
+++ b/OpenDocumentReader/Info-Lite.plist
@@ -56,10 +56,38 @@
 	<string>ca-app-pub-8161473686436957~5688952247</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>Copy image from document to your Photos</string>
+	<key>NSUserTrackingUsageDescription</key>
+	<string>This identifier will be used to deliver personalized ads to you.</string>
+	<key>SKAdNetworkItems</key>
+	<array>
+		<dict>
+			<key>SKAdNetworkIdentifier</key>
+			<string>cstr6suwn9.skadnetwork</string>
+		</dict>
+	</array>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
-	<key>UIMainStoryboardFile</key>
-	<string>Main</string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>arm64</string>
@@ -80,16 +108,5 @@
 	</array>
 	<key>UISupportsDocumentBrowser</key>
 	<true/>
-	<key>NSPhotoLibraryAddUsageDescription</key>
-	<string>Copy image from document to your Photos</string>
-	<key>NSUserTrackingUsageDescription</key>
-	<string>This identifier will be used to deliver personalized ads to you.</string>
-	<key>SKAdNetworkItems</key>
-	<array>
-		<dict>
-			<key>SKAdNetworkIdentifier</key>
-			<string>cstr6suwn9.skadnetwork</string>
-		</dict>
-	</array>
 </dict>
 </plist>

--- a/OpenDocumentReader/Info.plist
+++ b/OpenDocumentReader/Info.plist
@@ -58,10 +58,27 @@
 	<true/>
 	<key>NSPhotoLibraryAddUsageDescription</key>
 	<string>Copy image from document to your Photos</string>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
-	<key>UIMainStoryboardFile</key>
-	<string>Main</string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>arm64</string>

--- a/OpenDocumentReader/SceneDelegate.swift
+++ b/OpenDocumentReader/SceneDelegate.swift
@@ -1,0 +1,66 @@
+import UIKit
+
+/// Apple deprecated the app-delegate-only life cycle with the iOS 26 SDK, so
+/// window and URL handling live here now instead of in AppDelegate.
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+
+    var window: UIWindow?
+
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        guard let url = connectionOptions.urlContexts.first?.url else { return }
+
+        // the storyboard's root view controller is not wired up yet at this point
+        DispatchQueue.main.async {
+            self.open(url)
+        }
+    }
+
+    func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+        guard let url = URLContexts.first?.url else { return }
+
+        open(url)
+    }
+
+    /// Documents handed to us by other apps land in Documents/Inbox, which the
+    /// document browser does not show, so they get moved up one level first.
+    private func open(_ inputURL: URL) {
+        guard let documentBrowserViewController = window?.rootViewController as? DocumentBrowserViewController else {
+            CrashManager.shared.log("root view controller is not a DocumentBrowserViewController")
+
+            return
+        }
+
+        guard let documentsUrl = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {
+            CrashManager.shared.log("no documents directory")
+
+            return
+        }
+
+        let inboxUrl = documentsUrl.appendingPathComponent("Inbox")
+
+        let destinationUrl: URL
+        if inputURL.absoluteString.contains(inboxUrl.absoluteString) {
+            destinationUrl = documentsUrl.appendingPathComponent(inputURL.lastPathComponent)
+
+            do {
+                try FileManager.default.moveItem(at: inputURL, to: destinationUrl)
+            } catch {
+                CrashManager.shared.log(error)
+
+                return
+            }
+        } else {
+            destinationUrl = inputURL
+        }
+
+        documentBrowserViewController.revealDocument(at: destinationUrl, importIfNeeded: true) { revealedDocumentURL, _ in
+            guard let documentUrl = revealedDocumentURL else {
+                // ignoring errors because they should pop up in failedToImportDocumentAt too
+
+                return
+            }
+
+            documentBrowserViewController.presentDocument(at: documentUrl)
+        }
+    }
+}


### PR DESCRIPTION
Stacked on #114.

Apple deprecated the app-delegate-only life cycle with the iOS 26 SDK and has said it stops working in a future release. The app still had a `UIWindow` on `AppDelegate` and no scene manifest at all — this is the largest forward-compatibility item in the audit.

## Changes

- Both `Info.plist`s get a `UIApplicationSceneManifest` pointing at a new `SceneDelegate`; `UIMainStoryboardFile` is replaced by the manifest's `UISceneStoryboardFile`.
- Window ownership and the document-opening path move from `AppDelegate` to `SceneDelegate`, split across `willConnectTo` (cold launch with a URL) and `openURLContexts` (already-running app).
- The Documents/Inbox move keeps working exactly as before, minus a force-unwrap on the documents directory.
- `AppDelegate` gains `configurationForConnecting` and loses the six empty `applicationWill/Did…` stubs, which only ever held Xcode's template comments.

`UIApplicationSupportsMultipleScenes` stays **false**. Flipping it is what would give iPad multi-window, but `DocumentBrowserViewController` holds per-instance state (`documentController`) that has never been exercised with more than one scene — that deserves its own change.

## Verification

- Both flavors build and launch.
- Screenshotted the running app: the onboarding screen renders correctly under the scene lifecycle, which also confirms the localized `intro_next` button from #114.