### PR TITLE
Add a release workflow and take releases off one machine

### DIFF
--- a/.github/workflows/ios_release.yml
+++ b/.github/workflows/ios_release.yml
@@ -1,0 +1,138 @@
+name: OpenDocumentReader-iOS-release
+
+# Manual only. Releasing stays a deliberate act, this just moves it off
+# whoever's laptop happened to have the Apple ID signed in.
+on:
+  workflow_dispatch:
+    inputs:
+      flavor:
+        description: which app to upload
+        required: true
+        type: choice
+        options:
+          - pro
+          - lite
+          - both
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+env:
+  xcode_version: "26.0.1"
+
+jobs:
+  upload:
+    runs-on: macos-26
+    strategy:
+      fail-fast: true
+      max-parallel: 1
+      matrix:
+        flavor: ${{ inputs.flavor == 'both' && fromJSON('["pro","lite"]') || fromJSON(format('["{0}"]', inputs.flavor)) }}
+    steps:
+      - name: check secrets
+        env:
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          ASC_KEY_CONTENT: ${{ secrets.ASC_KEY_CONTENT }}
+          SIGNING_CERTIFICATE_P12: ${{ secrets.SIGNING_CERTIFICATE_P12 }}
+          SIGNING_CERTIFICATE_PASSWORD: ${{ secrets.SIGNING_CERTIFICATE_PASSWORD }}
+        run: |
+          missing=""
+          for name in ASC_KEY_ID ASC_ISSUER_ID ASC_KEY_CONTENT SIGNING_CERTIFICATE_P12 SIGNING_CERTIFICATE_PASSWORD; do
+            [ -z "${!name}" ] && missing="$missing $name"
+          done
+          if [ -n "$missing" ]; then
+            echo "::error::missing repository secrets:$missing (see README)"
+            exit 1
+          fi
+
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: checkout conan-odr-index
+        run: git submodule update --init --depth 1 conan-odr-index
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: ${{ env.xcode_version }}
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: install conan
+        run: pip3 install -r conan-odr-index/requirements.txt
+
+      - name: conan profile
+        run: conan profile detect
+
+      - name: conan cache key
+        id: conan-cache-key
+        run: echo "key=conan2-${{ runner.os }}-xcode${{ env.xcode_version }}-device-index$(git rev-parse HEAD:conan-odr-index)-${{ hashFiles('conan/conanfile.py', 'conan/profiles/*') }}" >> "$GITHUB_OUTPUT"
+
+      - name: conan cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.conan2/p
+          key: ${{ steps.conan-cache-key.outputs.key }}
+          restore-keys: |
+            conan2-${{ runner.os }}-xcode${{ env.xcode_version }}-device-
+
+      - name: export conan-odr-index
+        run: python3 conan-odr-index/scripts/conan_export_all_packages.py
+
+      - name: conan install
+        run: >
+          conan install conan/
+          --output-folder=conan-output
+          --build=missing
+          --profile:host=conan/profiles/ios
+          --deployer=conan/conandeployer.py
+          --deployer-folder=conan-assets
+          -o "configuration=${{ matrix.flavor == 'pro' && 'Release' || 'Release Lite' }}"
+
+      # a throwaway keychain so the distribution certificate never outlives the job
+      - name: import signing certificate
+        env:
+          SIGNING_CERTIFICATE_P12: ${{ secrets.SIGNING_CERTIFICATE_P12 }}
+          SIGNING_CERTIFICATE_PASSWORD: ${{ secrets.SIGNING_CERTIFICATE_PASSWORD }}
+        run: |
+          keychain="$RUNNER_TEMP/signing.keychain-db"
+          password="$(uuidgen)"
+
+          security create-keychain -p "$password" "$keychain"
+          security set-keychain-settings -lut 900 "$keychain"
+          security unlock-keychain -p "$password" "$keychain"
+
+          echo "$SIGNING_CERTIFICATE_P12" | base64 --decode > "$RUNNER_TEMP/certificate.p12"
+          security import "$RUNNER_TEMP/certificate.p12" \
+            -k "$keychain" \
+            -P "$SIGNING_CERTIFICATE_PASSWORD" \
+            -T /usr/bin/codesign \
+            -T /usr/bin/security
+          rm "$RUNNER_TEMP/certificate.p12"
+
+          security set-key-partition-list -S apple-tool:,apple: -k "$password" "$keychain" > /dev/null
+          security list-keychain -d user -s "$keychain" login.keychain-db
+
+      - name: upload to App Store Connect
+        env:
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          ASC_KEY_CONTENT: ${{ secrets.ASC_KEY_CONTENT }}
+        run: bundle exec fastlane ${{ matrix.flavor == 'pro' && 'deployPro' || 'deployLite' }}
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: build-log-${{ matrix.flavor }}
+          path: |
+            ~/Library/Logs/gym
+            *.ipa
+            *.app.dSYM.zip
+          if-no-files-found: warn

--- a/.github/workflows/ios_release.yml
+++ b/.github/workflows/ios_release.yml
@@ -19,7 +19,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  xcode_version: "26.0.1"
+  xcode_version: "26.5"
 
 jobs:
   upload:

--- a/README.md
+++ b/README.md
@@ -25,3 +25,32 @@ Everything else comes from Swift Package Manager and is resolved by Xcode.
 
 `conan/setup-all.sh` has to be re-run whenever the odrcore version in
 `conan/conanfile.py` or the `conan-odr-index` submodule changes.
+
+## Releasing
+
+The `OpenDocumentReader-iOS-release` workflow uploads a build to App Store
+Connect. It is manual (`workflow_dispatch`) and never submits for review, so
+promoting a build stays a deliberate step in App Store Connect. Build numbers
+come from whatever TestFlight already has, so nothing needs to be committed to
+cut a release.
+
+It needs these repository secrets:
+
+| secret | what it is |
+| --- | --- |
+| `ASC_KEY_ID` | App Store Connect API key id |
+| `ASC_ISSUER_ID` | issuer id of that key |
+| `ASC_KEY_CONTENT` | the `.p8` private key, base64 encoded |
+| `SIGNING_CERTIFICATE_P12` | Apple Distribution certificate + key as a base64 encoded `.p12` |
+| `SIGNING_CERTIFICATE_PASSWORD` | password of that `.p12` |
+
+The certificate is imported into a temporary keychain that is discarded with the
+runner. Provisioning profiles are created on demand via
+`-allowProvisioningUpdates`.
+
+The same lanes work locally once those variables are exported:
+
+```bash
+bundle exec fastlane deployPro
+bundle exec fastlane deployLite
+```

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -10,6 +10,11 @@
 #     https://docs.fastlane.tools/plugins/available-plugins
 #
 
+require "base64"
+require "fileutils"
+require "shellwords"
+require "tmpdir"
+
 default_platform(:ios)
 
 APPS = {
@@ -42,48 +47,74 @@ platform :ios do
   # is what kept releases tied to one person's machine. Supply it through
   # ASC_KEY_ID / ASC_ISSUER_ID / ASC_KEY_CONTENT, the last being the base64 of
   # the .p8 file.
-  private_lane :api_key do
-    app_store_connect_api_key(
-      key_id: ENV.fetch("ASC_KEY_ID"),
-      issuer_id: ENV.fetch("ASC_ISSUER_ID"),
-      key_content: ENV.fetch("ASC_KEY_CONTENT"),
-      is_key_content_base64: true,
-      in_house: false
-    )
+  #
+  # The key has to hit the disk because two unrelated consumers need it: the
+  # Connect API calls fastlane makes itself, and the xcodebuild subprocess that
+  # build_app spawns. xcodebuild knows nothing about fastlane's key -- see
+  # -authenticationKeyPath in `xcodebuild -help` -- so it gets the file.
+  private_lane :api_key_file do
+    path = File.join(Dir.mktmpdir("asc-api-key"), "AuthKey_#{ENV.fetch('ASC_KEY_ID')}.p8")
+    File.write(path, Base64.decode64(ENV.fetch("ASC_KEY_CONTENT")))
+    File.chmod(0o600, path)
+
+    path
   end
 
   private_lane :deploy do |options|
-    key = api_key
+    key_path = api_key_file
 
-    # the build number used to be bumped by hand in project.pbxproj. Derive it
-    # from what App Store Connect already has instead, so two releases cannot
-    # collide and nothing has to be committed to make a build
-    build_number = latest_testflight_build_number(
-      api_key: key,
-      app_identifier: options[:app_identifier],
-      initial_build_number: 0
-    ) + 1
+    begin
+      key = app_store_connect_api_key(
+        key_id: ENV.fetch("ASC_KEY_ID"),
+        issuer_id: ENV.fetch("ASC_ISSUER_ID"),
+        key_filepath: key_path,
+        in_house: false
+      )
 
-    UI.message("building #{options[:scheme]} as build #{build_number}")
+      # the build number used to be bumped by hand in project.pbxproj. Derive it
+      # from what App Store Connect already has instead, so two releases cannot
+      # collide and nothing has to be committed to make a build
+      build_number = latest_testflight_build_number(
+        api_key: key,
+        app_identifier: options[:app_identifier],
+        initial_build_number: 0
+      ) + 1
 
-    build_app(
-      project: "OpenDocumentReader.xcodeproj",
-      scheme: options[:scheme],
-      api_key: key,
-      # passed on the command line rather than written into project.pbxproj, so
-      # a release never leaves the working tree dirty
-      xcargs: "-allowProvisioningUpdates CURRENT_PROJECT_VERSION=#{build_number}"
-    )
+      UI.message("building #{options[:scheme]} as build #{build_number}")
 
-    upload_to_app_store(
-      api_key: key,
-      app_identifier: options[:app_identifier],
-      skip_screenshots: true,
-      skip_metadata: true,
-      # uploading is not the same as shipping: promoting a build stays a
-      # deliberate step in App Store Connect
-      skip_submission: true,
-      precheck_include_in_app_purchases: false
-    )
+      # build_app is gym, which has no api_key option -- passing one aborts the
+      # lane before xcodebuild ever runs. Automatic signing is authenticated
+      # through xcargs instead: -allowProvisioningUpdates on its own needs an
+      # Apple account configured in Xcode, which the release runner does not
+      # have.
+      xcargs = [
+        "-allowProvisioningUpdates",
+        "-authenticationKeyPath", Shellwords.escape(key_path),
+        "-authenticationKeyID", Shellwords.escape(ENV.fetch("ASC_KEY_ID")),
+        "-authenticationKeyIssuerID", Shellwords.escape(ENV.fetch("ASC_ISSUER_ID")),
+        # passed on the command line rather than written into project.pbxproj,
+        # so a release never leaves the working tree dirty
+        "CURRENT_PROJECT_VERSION=#{build_number}",
+      ].join(" ")
+
+      build_app(
+        project: "OpenDocumentReader.xcodeproj",
+        scheme: options[:scheme],
+        xcargs: xcargs
+      )
+
+      upload_to_app_store(
+        api_key: key,
+        app_identifier: options[:app_identifier],
+        skip_screenshots: true,
+        skip_metadata: true,
+        # uploading is not the same as shipping: promoting a build stays a
+        # deliberate step in App Store Connect
+        skip_submission: true,
+        precheck_include_in_app_purchases: false
+      )
+    ensure
+      FileUtils.remove_entry(File.dirname(key_path), true)
+    end
   end
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -10,34 +10,22 @@
 #     https://docs.fastlane.tools/plugins/available-plugins
 #
 
-# Uncomment the line if you want fastlane to automatically update itself
-# update_fastlane
-
 default_platform(:ios)
 
+APPS = {
+  pro: { scheme: "ODR Full", app_identifier: "at.tomtasche.reader" },
+  lite: { scheme: "ODR Lite", app_identifier: "at.tomtasche.reader.lite1" },
+}.freeze
+
 platform :ios do
-  desc "Push a new release build to the App Store"
-  lane :deployPro do
-    clear_derived_data
-    build_app(project: "OpenDocumentReader.xcodeproj", scheme: "ODR Full", xcargs: "-allowProvisioningUpdates")
-    upload_to_app_store(
-      app_identifier: "at.tomtasche.reader",
-      skip_screenshots: true,
-      skip_metadata: true
-    )
-    clear_derived_data
+  desc "Push a new release build of the paid app to the App Store"
+  lane :deployPro do |options|
+    deploy(options.merge(APPS[:pro]))
   end
 
-  desc "Push a new release build to the App Store"
-  lane :deployLite do
-    clear_derived_data
-    build_app(project: "OpenDocumentReader.xcodeproj", scheme: "ODR Lite", xcargs: "-allowProvisioningUpdates")
-    upload_to_app_store(
-      app_identifier: "at.tomtasche.reader.lite1",
-      skip_screenshots: true,
-      skip_metadata: true
-    )
-    clear_derived_data
+  desc "Push a new release build of the ad supported app to the App Store"
+  lane :deployLite do |options|
+    deploy(options.merge(APPS[:lite]))
   end
 
   lane :tests do
@@ -46,8 +34,56 @@ platform :ios do
     run_tests(
       project: "OpenDocumentReader.xcodeproj",
       scheme: "ODR Full",
-      prelaunch_simulator: true,
-      xcargs: "-allowProvisioningUpdates"
+      prelaunch_simulator: true
+    )
+  end
+
+  # An App Store Connect API key replaces the interactive Apple ID login, which
+  # is what kept releases tied to one person's machine. Supply it through
+  # ASC_KEY_ID / ASC_ISSUER_ID / ASC_KEY_CONTENT, the last being the base64 of
+  # the .p8 file.
+  private_lane :api_key do
+    app_store_connect_api_key(
+      key_id: ENV.fetch("ASC_KEY_ID"),
+      issuer_id: ENV.fetch("ASC_ISSUER_ID"),
+      key_content: ENV.fetch("ASC_KEY_CONTENT"),
+      is_key_content_base64: true,
+      in_house: false
+    )
+  end
+
+  private_lane :deploy do |options|
+    key = api_key
+
+    # the build number used to be bumped by hand in project.pbxproj. Derive it
+    # from what App Store Connect already has instead, so two releases cannot
+    # collide and nothing has to be committed to make a build
+    build_number = latest_testflight_build_number(
+      api_key: key,
+      app_identifier: options[:app_identifier],
+      initial_build_number: 0
+    ) + 1
+
+    UI.message("building #{options[:scheme]} as build #{build_number}")
+
+    build_app(
+      project: "OpenDocumentReader.xcodeproj",
+      scheme: options[:scheme],
+      api_key: key,
+      # passed on the command line rather than written into project.pbxproj, so
+      # a release never leaves the working tree dirty
+      xcargs: "-allowProvisioningUpdates CURRENT_PROJECT_VERSION=#{build_number}"
+    )
+
+    upload_to_app_store(
+      api_key: key,
+      app_identifier: options[:app_identifier],
+      skip_screenshots: true,
+      skip_metadata: true,
+      # uploading is not the same as shipping: promoting a build stays a
+      # deliberate step in App Store Connect
+      skip_submission: true,
+      precheck_include_in_app_purchases: false
     )
   end
 end

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -21,7 +21,7 @@ For _fastlane_ installation instructions, see [Installing _fastlane_](https://do
 [bundle exec] fastlane ios deployPro
 ```
 
-Push a new release build to the App Store
+Push a new release build of the paid app to the App Store
 
 ### ios deployLite
 
@@ -29,7 +29,7 @@ Push a new release build to the App Store
 [bundle exec] fastlane ios deployLite
 ```
 
-Push a new release build to the App Store
+Push a new release build of the ad supported app to the App Store
 
 ### ios tests
 


### PR DESCRIPTION
Stacked on #115. Last PR in the modernization stack.

Releases needed an interactive Apple ID login and a hand-edited `CURRENT_PROJECT_VERSION` in `project.pbxproj`, so only whoever had the account signed in could ship.

## Changes

**Authentication** — the deploy lanes use an App Store Connect API key (`ASC_KEY_ID` / `ASC_ISSUER_ID` / `ASC_KEY_CONTENT`) instead of an Apple ID session.

**Build numbers** — derived from the highest build TestFlight already knows, `+1`, and passed as an xcarg. No more editing the pbxproj to cut a release, and no way for two releases to collide.

**Uploads no longer submit for review.** `skip_submission: true` means a build lands in App Store Connect and promoting it stays a deliberate step — which is what makes running this from CI reasonable at all. Note this *is* a behavior change from the current lanes.

**Deduplication** — `deployPro` and `deployLite` were copies of each other; they now share a private `deploy` lane.

**Workflow** — `workflow_dispatch` only, takes `pro`/`lite`/`both`. It checks the required secrets exist up front and fails with a readable message rather than dying halfway through a build, and imports the distribution certificate into a throwaway keychain that dies with the runner.

Also removed the two `clear_derived_data` calls wrapping every deploy, and `-allowProvisioningUpdates` from the `tests` lane, where simulator tests never signed anything.

Required secrets are documented in the README.

## Verification, and its limits

- Fastfile parses; `fastlane lanes` lists `deployPro`, `deployLite`, `tests`.
- `bundle exec fastlane tests` still passes (5 tests, 0 failures) after the rewrite.
- Release workflow YAML validates.

**I have no Apple credentials, so the upload path has never actually run.** Everything up to `build_app` is already exercised by the device build job in #109, but `latest_testflight_build_number`, signing and `upload_to_app_store` are unproven. The first dispatch should be treated as a test run — pick `lite`.

The alternative to importing a `.p12` is `fastlane match`, which is the more standard answer but needs a private certificates repo I could not create. Happy to switch to it if you want to set one up.