### PR TITLE
Pin the setup venv to python 3.12 and ignore it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ fastlane/report.xml
 conan-output/
 conan-assets/
 graph_info.json
+.venv/

--- a/README.md
+++ b/README.md
@@ -9,13 +9,17 @@ Our C++ dependencies come from [conan-odr-index](https://github.com/opendocument
 which is checked out as a submodule and exported into the local conan cache. No
 private conan remote is involved.
 
+The helper scripts in that submodule need python 3.12 or newer — they use PEP
+701 f-strings, which are a syntax error on 3.11.
+
 1. `git submodule update --init --depth 1 conan-odr-index`
-2. install conan into a venv: `pip install -r conan-odr-index/requirements.txt`
-3. `conan profile detect`
-4. `conan/setup-all.sh` — exports the recipes and generates the xcconfigs for
+2. `python3.12 -m venv .venv && source .venv/bin/activate`
+3. install conan into that venv: `pip install -r conan-odr-index/requirements.txt`
+4. `conan profile detect`
+5. `conan/setup-all.sh` — exports the recipes and generates the xcconfigs for
    every configuration and architecture. The first run builds odrcore and its
    dependencies from source and takes a while.
-5. open `OpenDocumentReader.xcodeproj` in Xcode
+6. open `OpenDocumentReader.xcodeproj` in Xcode
 
 Everything else comes from Swift Package Manager and is resolved by Xcode.
 


### PR DESCRIPTION
Follow-up to #108. Rebased onto main now that #113 has landed, which absorbed part of this branch — see the last section.

**The venv had no version floor.** conan installs happily on python 3.11, and then `conan/setup-all.sh` calls the index's helper scripts and dies:

```
  File "conan-odr-index/scripts/conan_export_all_packages.py", line 104
    f"Export package {package_info["package"]} version {package_info["version"]} ..."
                                    ^^^^^^^
SyntaxError: f-string: unmatched '['
```

PEP 701 nested quotes, so 3.12 is the floor. CI already pins `python-version: "3.12"` for exactly this reason — only the README was silent about it.

Verified by compiling the submodule's scripts under both interpreters: 3.11 raises the error above, 3.12 is clean.

**`.venv/` is now ignored.** Codex flagged this on the first revision and it's right: the step above creates the venv inside the checkout, and nothing in `.gitignore` matched it, so following the documented setup left a dirty tree with a large machine-specific directory sitting in `git status`.

**What the rebase dropped.** This branch also reordered the steps so the submodule checkout precedes the `pip install` that reads `conan-odr-index/requirements.txt`. #113 made that same reordering while replacing CocoaPods with SPM, so the rebase resolved to just the python floor plus the `.gitignore` entry. The remaining README diff is 12 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019978mDv7veoaSpByQPCnNe
