### PR TITLE
Bump odrcore to 5.7.0 and drop the cli tools

### DIFF
--- a/conan/conanfile.py
+++ b/conan/conanfile.py
@@ -11,8 +11,9 @@ class Pkg(ConanFile):
         "odrcore/*:with_wvWare": False,
         "odrcore/*:with_libmagic": False,
         "odrcore/*:with_http_server": True,
+        "odrcore/*:with_cli": False,
     }
-    requires = "odrcore/5.5.0"
+    requires = "odrcore/5.7.0"
 
     def generate(self):
         xcode = XcodeDeps(self)


### PR DESCRIPTION
Updates the `conan-odr-index` submodule from `bump odrcore 5.5.0` (49780d8) to `odrcore/5: expose ODR_CLI as \`with_cli\`` (010a878) and moves the app to the newest core the index offers.

Index commits picked up:

- `2deccad` bump odrcore 5.6.0
- `9a4a8d0` bump odrcore 5.7.0
- `36f5dc9` odrcore/5: version-gate options that older cores lack
- `010a878` odrcore/5: expose ODR_CLI as `with_cli`

With the options now version-gated, setting one the requested core does not know about is an error rather than a silent no-op, so the option list here is checked against 5.7.0.

`with_cli=False` is new. We only link the library, but the cli tools were built and installed with every package anyway. 5.7.0 is the first core whose install step skips the cli targets it did not build, so turning it off was not possible before this bump.

## Testing

- `conan/setup-all.sh` — all four configurations on device and both simulator architectures, 13/13 installs, odrcore built from source
- `xcodebuild` `ODR Full`/`Release` and `ODR Lite`/`Release Lite` for `iphoneos` — both succeed
- `bundle exec fastlane tests` — 20 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)