### PR TITLE
Fix the option that keeps a release off review

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -153,8 +153,9 @@ platform :ios do
           skip_screenshots: true,
           skip_metadata: true,
           # uploading is not the same as shipping: promoting a build stays a
-          # deliberate step in App Store Connect
-          skip_submission: true,
+          # deliberate step in App Store Connect. deliver's option is
+          # submit_for_review; skip_submission is pilot's and is rejected here.
+          submit_for_review: false,
           precheck_include_in_app_purchases: false
         )
       end


### PR DESCRIPTION
The 1.37 release run archived, signed and exported an ipa, then failed before uploading it:

```
[!] Could not find option 'skip_submission' in the list of available options: ...
```

`skip_submission` is a `pilot` (`upload_to_testflight`) option. `upload_to_app_store` is `deliver`, whose equivalent is `submit_for_review` — and that already defaults to `false`, so the intent was right and only the name was wrong. Passing it explicitly keeps the intent visible.

Checked against the same fastlane 2.237.0 the runner uses: every key now passed to `upload_to_app_store` exists in `Deliver::Options`.

Nothing was uploaded by the failed run, so build 43 is still free — TestFlight is on 42/1.36. Once this lands, 1.37 can go out with a `workflow_dispatch` on main with version `1.37`; no re-tagging needed.

[Failed run](https://github.com/opendocument-app/OpenDocument.ios/actions/runs/30767461563)

🤖 Generated with [Claude Code](https://claude.com/claude-code)