### PR TITLE
Keep a changelog on main and the store copy in fastlane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,83 @@
+# Changelog
+
+User-facing changes to OpenDocument Reader for iOS. Changes to the shared
+OpenDocument core that the app picked up are listed under the release that
+shipped them.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+Entries go under `Unreleased` as the change lands, in the same pull request.
+Cutting a release renames that heading to the version and adds its compare
+link; nothing in the build reads this file, so `project.pbxproj` keeps its
+`0.0.0` and the version still comes from the tag.
+
+The copy that App Store Connect shows under "What's New" is a different, shorter
+register, and lives in `fastlane/metadata/en-US/changelogs/<version>.txt`. It is
+pasted into App Store Connect at submission time; see the README there.
+
+## [Unreleased]
+
+## [1.37] - 2026-08-02
+
+No user-facing changes. This release only changes how the app is built and
+submitted.
+
+## [1.36] - 2026-08-02
+
+### Added
+
+- Legacy Microsoft formats (.doc, .xls, .ppt) are read by our own
+  implementation: character formatting, cell fonts and fills, embedded
+  pictures, real slide sizes and slide names.
+- OOXML documents: PowerPoint slide size and tables, Excel merged cells and
+  value types, Word table merges and line breaks.
+- ODF documents: subscript and superscript, percentage line height, first-line
+  indent.
+- Documents with fixed-size content open fit-to-width on phones.
+
+### Changed
+
+- Requires iOS 15 or later.
+- The app no longer collects analytics and no longer reports crashes. All
+  Firebase components were removed.
+- Pages are rendered when you open them instead of all at once. Documents with
+  many pages, slides or sheets open faster, and switching between them no
+  longer re-reads the file.
+- The page tabs were rewritten: they follow light and dark appearance, each tab
+  takes only the width of its own title so one long sheet name no longer pushes
+  the others off screen, and they are reachable with VoiceOver.
+- File type detection is more reliable, so documents with a wrong or missing
+  extension open more often.
+
+### Fixed
+
+- Failures are reported instead of ending the app. Documents where no page
+  could be shown, failed imports and a few other states previously crashed.
+- Saving an edited document no longer stalls for 30 seconds when the save
+  fails; the error is reported right away.
+- Word documents: line breaks inside paragraphs are kept.
+- PowerPoint documents: read-only files are reported as read-only, and text
+  split across several runs is no longer broken apart.
+
+## [1.35] - 2025-06-12
+
+### Added
+
+- Support for the newer ODF encryption scheme, so encrypted documents that
+  previously failed to open now open.
+- Documents follow the system light and dark appearance.
+
+### Changed
+
+- Colors in OOXML documents are closer to the original.
+- General improvements to page styling.
+
+### Fixed
+
+- An incorrect password is now reported as such instead of a generic failure.
+- Page handling and decryption fixes when opening protected documents.
+
+[Unreleased]: https://github.com/opendocument-app/OpenDocument.ios/compare/1.37...HEAD
+[1.37]: https://github.com/opendocument-app/OpenDocument.ios/compare/1.36...1.37
+[1.36]: https://github.com/opendocument-app/OpenDocument.ios/compare/1.35...1.36
+[1.35]: https://github.com/opendocument-app/OpenDocument.ios/compare/1.34...1.35

--- a/fastlane/metadata/en-US/changelogs/1.35.txt
+++ b/fastlane/metadata/en-US/changelogs/1.35.txt
@@ -1,0 +1,5 @@
+- Support for the newer ODF encryption scheme
+- Documents follow the system light and dark appearance
+- More accurate colors in Word, Excel and PowerPoint documents
+- An incorrect password is now reported as such
+- Fixes for page handling and decryption of protected documents

--- a/fastlane/metadata/en-US/changelogs/1.36.txt
+++ b/fastlane/metadata/en-US/changelogs/1.36.txt
@@ -1,0 +1,9 @@
+- Legacy Word, Excel and PowerPoint files (.doc, .xls, .ppt) are read by our own implementation, with character formatting, cell fonts and fills, pictures, slide sizes and slide names
+- Better support for Word tables and line breaks, Excel merged cells and value types, and PowerPoint slide sizes and tables
+- ODF documents: subscript and superscript, percentage line height, first-line indent
+- Pages are rendered when you open them, so documents with many pages, slides or sheets open faster
+- Rewritten page tabs: readable in dark mode, no longer pushed off screen by a long sheet name, and usable with VoiceOver
+- More reliable file type detection
+- The app no longer collects analytics and no longer reports crashes
+- Several crashes fixed, and failures are now reported instead of ending the app
+- Requires iOS 15 or later

--- a/fastlane/metadata/en-US/changelogs/1.37.txt
+++ b/fastlane/metadata/en-US/changelogs/1.37.txt
@@ -1,0 +1,1 @@
+This release only changes how the app is built and submitted. There are no changes to the app itself.

--- a/fastlane/metadata/en-US/changelogs/README.md
+++ b/fastlane/metadata/en-US/changelogs/README.md
@@ -1,0 +1,23 @@
+# Release notes
+
+One file per marketing version, holding the "What's New" text for that
+submission. Written for users of the app, not for this repository: the
+developer-facing record of the same release is in `CHANGELOG.md` at the root.
+
+Named by marketing version (`1.37.txt`), not by build number. The build number
+is a live query of what TestFlight already has, so it is not known until a
+release run starts and cannot name a file committed ahead of it.
+
+`deliver` does not read this directory. It reads one file per locale,
+`fastlane/metadata/<locale>/release_notes.txt`, and the upload skips metadata
+entirely (`skip_metadata: true` in `fastlane/Fastfile`), because promoting a
+build is a deliberate step in App Store Connect rather than something a tag
+push does. So the notes for a release are pasted into App Store Connect by
+hand, from the file for that version.
+
+App Store Connect keeps only the notes for the version being submitted, so
+these files are the history that the store does not keep. The limit is 4000
+characters.
+
+Only en-US is kept, matching OpenDocument.droid. Other locales fall back to the
+English text in the store.


### PR DESCRIPTION
Adds a changelog, and puts the two kinds of release text where each one belongs.

## Why not a release branch

The tempting shape is a long-lived branch holding versioned notes, since main
deliberately knows nothing about versions — `project.pbxproj` holds `0.0.0` and
the version reaches the build from the tag. But a changelog records what
changed, which is a property of the commits, so separating it costs more than
it saves:

- It puts back the release commit #127 removed. `release.yml` says it outright:
  the tag reaches xcodebuild as `MARKETING_VERSION`, "so a release needs no
  commit". A release branch makes every release a commit again.
- A tag's own tree would not contain its notes. Tags point at main, so
  `git show 1.36:CHANGELOG.md` would fail and "what shipped in 1.36" would stop
  being answerable from `1.36`.
- Entries would be reconstructed afterwards from `git log` instead of written
  with the change. That is the process that produced the empty `1.17` release
  body.
- GitHub renders `CHANGELOG.md` from the default branch, so on a side branch
  contributors would not find it.

Keep a Changelog already solves the version-awareness part with `Unreleased`:
entries land under that heading in the pull request that causes them, and
cutting a release renames the heading and adds the compare link. Main knows
versions historically, never as a build input.

## What moved

`CHANGELOG.md` covers 1.35 through 1.37 and keeps only the developer-facing
record. The App Store "What's New" copy that was appended to it moves to
`fastlane/metadata/en-US/changelogs/<version>.txt`, one file per marketing
version, mirroring OpenDocument.droid.

The mirror is not exact, and the README in that directory says why. On droid,
`supply` reads the directory and Play retains every version's notes as
user-visible history. On iOS, `deliver` reads a single `release_notes.txt` per
locale and App Store Connect keeps only the notes for the submission in flight.
So here the directory is the history the store does not keep, and the notes are
pasted in by hand at submission — which leaves promoting a build the deliberate
step it already is.

Files are named by marketing version rather than build number because the build
number is a live query of what TestFlight already has: it is not known until a
release run starts, so it cannot name a file committed ahead of it.

## Risk

None to the release path. No tracked file changes — `Fastfile`, `release.yml`
and `project.pbxproj` are untouched, `skip_metadata` stays `true`, and nothing
new can reach App Store Connect. Everything here is additive.

Left alone deliberately: `fastlane/metadata/en-US/release_notes.txt` still
reads "Add search functionality for ODF documents", which is years stale. It is
inert while `skip_metadata` is `true`, but it is the file `deliver` would read
first if that ever flips. Syncing or deleting it touches a tracked 10-locale
metadata set, so it seemed worth deciding separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)