### PR TITLE
Stop the Lite manifest from claiming tracking it cannot name

### DIFF
--- a/OpenDocumentReader/Privacy/Lite/PrivacyInfo.xcprivacy
+++ b/OpenDocumentReader/Privacy/Lite/PrivacyInfo.xcprivacy
@@ -2,8 +2,12 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<!-- The ads SDKs declare their own tracking and Apple aggregates the
+	     manifests, so this covers the app itself. Domains stay empty because iOS
+	     blocks whatever is listed here when ATT is denied, which would also cut
+	     off the non-personalized ads. true with an empty list is ITMS-91064. -->
 	<key>NSPrivacyTracking</key>
-	<true/>
+	<false/>
 	<key>NSPrivacyTrackingDomains</key>
 	<array/>
 	<key>NSPrivacyCollectedDataTypes</key>

--- a/fastlane/metadata/en-US/changelogs/1.37.txt
+++ b/fastlane/metadata/en-US/changelogs/1.37.txt
@@ -1,1 +1,9 @@
-This release only changes how the app is built and submitted. There are no changes to the app itself.
+- Legacy Word, Excel and PowerPoint files (.doc, .xls, .ppt) are read by our own implementation, with character formatting, cell fonts and fills, pictures, slide sizes and slide names
+- Better support for Word tables and line breaks, Excel merged cells and value types, and PowerPoint slide sizes and tables
+- ODF documents: subscript and superscript, percentage line height, first-line indent
+- Pages are rendered when you open them, so documents with many pages, slides or sheets open faster
+- Rewritten page tabs: readable in dark mode, no longer pushed off screen by a long sheet name, and usable with VoiceOver
+- More reliable file type detection
+- More privacy: your documents never leave your device, and the app sends us no usage data
+- Several crashes fixed, and failures are now reported instead of ending the app
+- Requires iOS 15 or later


### PR DESCRIPTION
Build 43 of the Lite app came back **ITMS-91064 / Invalid Binary**: its `PrivacyInfo.xcprivacy` set `NSPrivacyTracking` to `true` while `NSPrivacyTrackingDomains` was empty, which App Review rejects. Pro passed the same upload with `false` and an empty list, so this mirrors it.

The manifests only landed in #107, after 1.35 shipped, so this file had never been through App Store validation before — 1.37 build 43 was its first upload.

### Why not just list the AdMob domains

That would satisfy the rule but cost more than it buys. iOS blocks the domains named in `NSPrivacyTrackingDomains` whenever ATT authorization is missing, so listing the AdMob endpoints would also cut off the **non-personalized** ads served to users who decline the prompt. The Google SDKs ship no domains of their own for that reason, and `GoogleMobileAds` already marks `DeviceID` as `NSPrivacyCollectedDataTypeTracking` in its own manifest, which Apple aggregates with this one. The tracking disclosure is still made.

Verified against the shipped artifacts from run 30767906998, not just the source:

| build 43 | `NSPrivacyTracking` | `NSPrivacyTrackingDomains` | outcome |
|---|---|---|---|
| Pro | `false` | empty | passed |
| Lite | `true` | empty | ITMS-91064 |

### Also

Corrects `1.37.txt` to the copy actually submitted. 1.36 was tagged but never reached the store, so App Store Connect jumps 1.35 → 1.37 and the notes have to cover the 1.36 work.

Pro 1.37 (build 43) is unaffected and still Waiting for Review. Lite needs a new build from this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)