### PR TITLE
Ask for consent before showing an ad, serve limited ads without it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,20 @@ once the version tag exists.
 
 ## [Unreleased]
 
+### Added
+
+- The Lite app asks for advertising consent before it shows its first ad, in
+  the regions where Google's EU user consent policy requires a consent form.
+  The form is Google's own (UMP), the same one the Android app uses.
+- A "Privacy" entry in the document browser reopens that choice, and leads to
+  the system tracking permission.
+
+### Changed
+
+- The tracking permission is asked after the consent form, and only where the
+  answer allows an ad to carry an advertising identifier. Refusing consent
+  leaves limited ads, which carry none, rather than no ads at all.
+
 ## [1.37]
 
 No user-facing changes. This release only changes how the app is built and

--- a/OpenDocumentReader.xcodeproj/project.pbxproj
+++ b/OpenDocumentReader.xcodeproj/project.pbxproj
@@ -20,9 +20,11 @@
 		AC384BCF23B4FFA700C7BF47 /* PageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC384BCB23B4FFA700C7BF47 /* PageViewController.swift */; };
 		ACA46529244E403900A5DA7A /* AppType.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACA46528244E403900A5DA7A /* AppType.swift */; };
 		ACD9BE3C2444A371009014E6 /* ConfigurationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACD9BE2D2444A371009014E6 /* ConfigurationManager.swift */; };
+		C0A5E1100000000000000001 /* ConsentManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A5E1100000000000000002 /* ConsentManager.swift */; };
 		BFFB694BE9E3E744FD4F92E0 /* CrashManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25ACB597DDB073F3AFC74345 /* CrashManager.swift */; };
 		C43B65A97E4029F7790DA729 /* CoreWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C00CD0A89EF1F64FF879A1 /* CoreWrapper.swift */; };
 		D2DCD7104EBCC0F1A784E116 /* GoogleMobileAds in Frameworks */ = {isa = PBXBuildFile; productRef = B5F033C5AA89A6E9C19EA27D /* GoogleMobileAds */; };
+		C0A5E1100000000000000005 /* GoogleUserMessagingPlatform in Frameworks */ = {isa = PBXBuildFile; productRef = C0A5E1100000000000000004 /* GoogleUserMessagingPlatform */; };
 		E1A78CF72C1A53DB00CD43E4 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E1EB6C492C1A510D003EC5A0 /* Foundation.framework */; };
 		E2064DFE22CFA1BA006441F8 /* iAd.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E2064DDF22CFA1BA006441F8 /* iAd.framework */; };
 		E22B252F2557F0E2001D0C52 /* OpenDocumentReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E22B252E2557F0E2001D0C52 /* OpenDocumentReaderTests.swift */; };
@@ -87,6 +89,7 @@
 		AC73790F2438E52B00F9F3B5 /* sl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sl; path = sl.lproj/Localizable.strings; sourceTree = "<group>"; };
 		ACA46528244E403900A5DA7A /* AppType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppType.swift; sourceTree = "<group>"; };
 		ACD9BE2D2444A371009014E6 /* ConfigurationManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConfigurationManager.swift; sourceTree = "<group>"; };
+		C0A5E1100000000000000002 /* ConsentManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConsentManager.swift; sourceTree = "<group>"; };
 		ACF1A3E42469F8DE000BA420 /* Info-Lite.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Info-Lite.plist"; sourceTree = "<group>"; };
 		B01C1B2BA00A7917FF7D7726 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		B94897965C815527C6C06996 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
@@ -138,6 +141,7 @@
 				523A371328CCF27400876C77 /* AdServices.framework in Frameworks */,
 				E1A78CF72C1A53DB00CD43E4 /* Foundation.framework in Frameworks */,
 				D2DCD7104EBCC0F1A784E116 /* GoogleMobileAds in Frameworks */,
+				C0A5E1100000000000000005 /* GoogleUserMessagingPlatform in Frameworks */,
 				FB494C85E264BD924C1EA54E /* OdrCore in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -244,6 +248,7 @@
 				AC384BC923B4FFA700C7BF47 /* ContentViewController.swift */,
 				AC384BCB23B4FFA700C7BF47 /* PageViewController.swift */,
 				ACD9BE2D2444A371009014E6 /* ConfigurationManager.swift */,
+				C0A5E1100000000000000002 /* ConsentManager.swift */,
 				E22EB717226B633500053B86 /* Document.swift */,
 				E22EB71B226B66B300053B86 /* Main.storyboard */,
 				E2F7ED5D220B54D700D63515 /* Assets.xcassets */,
@@ -296,6 +301,7 @@
 			name = OpenDocumentReader;
 			packageProductDependencies = (
 				B5F033C5AA89A6E9C19EA27D /* GoogleMobileAds */,
+				C0A5E1100000000000000004 /* GoogleUserMessagingPlatform */,
 				E381918B979121CD165C966A /* OdrCore */,
 			);
 			productName = "OpenDocument Reader";
@@ -349,6 +355,7 @@
 			mainGroup = E2F7ED46220B54D600D63515;
 			packageReferences = (
 				AD584FCD41577C8CDEE974AA /* XCRemoteSwiftPackageReference "swift-package-manager-google-mobile-ads" */,
+				C0A5E1100000000000000003 /* XCRemoteSwiftPackageReference "swift-package-manager-google-user-messaging-platform" */,
 				78200B97C10509E2539B4FE5 /* XCRemoteSwiftPackageReference "OpenDocument.core" */,
 			);
 			productRefGroup = E2F7ED46220B54D600D63515;
@@ -410,6 +417,7 @@
 				E22EB716226B621200053B86 /* DocumentBrowserTransitioningDelegate.swift in Sources */,
 				ACA46529244E403900A5DA7A /* AppType.swift in Sources */,
 				ACD9BE3C2444A371009014E6 /* ConfigurationManager.swift in Sources */,
+				C0A5E1100000000000000001 /* ConsentManager.swift in Sources */,
 				AC384BCE23B4FFA700C7BF47 /* Constants.swift in Sources */,
 				E2F7ED55220B54D600D63515 /* DocumentBrowserViewController.swift in Sources */,
 				E2F7ED53220B54D600D63515 /* AppDelegate.swift in Sources */,
@@ -978,6 +986,14 @@
 				minimumVersion = 13.7.0;
 			};
 		};
+		C0A5E1100000000000000003 /* XCRemoteSwiftPackageReference "swift-package-manager-google-user-messaging-platform" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/googleads/swift-package-manager-google-user-messaging-platform.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 3.1.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -990,6 +1006,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 78200B97C10509E2539B4FE5 /* XCRemoteSwiftPackageReference "OpenDocument.core" */;
 			productName = OdrCore;
+		};
+		C0A5E1100000000000000004 /* GoogleUserMessagingPlatform */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C0A5E1100000000000000003 /* XCRemoteSwiftPackageReference "swift-package-manager-google-user-messaging-platform" */;
+			productName = GoogleUserMessagingPlatform;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/OpenDocumentReader/ConsentManager.swift
+++ b/OpenDocumentReader/ConsentManager.swift
@@ -33,6 +33,10 @@ final class ConsentManager {
     /// decision to fail in the first place. Treating those errors as a refusal would hide the
     /// banner from users who had already said yes.
     ///
+    /// It is not a report of what the user chose, either: the property says only that an answer
+    /// has been gathered, and "do not consent" is an answer. What that answer allows is
+    /// `adsMayUseAdvertisingIdentifier` below.
+    ///
     /// The completion runs on the main queue.
     func gatherConsent(from viewController: UIViewController, completion: @escaping (Bool) -> Void) {
         requestUpdate { updated in
@@ -64,6 +68,26 @@ final class ConsentManager {
                 completion()
             }
         }
+    }
+
+    /// Whether an ad shown to this user may carry an advertising identifier, and so whether ATT
+    /// has anything to govern.
+    ///
+    /// The CMP writes the TCF signals into `UserDefaults`, as the framework requires. The first
+    /// flag of `IABTCF_PurposeConsents` is purpose 1, storing and reading information on the
+    /// device; without it Google can serve neither personalised nor non-personalised ads and falls
+    /// back to limited ads, which carry no identifier at all. A user who allowed purpose 1 and
+    /// refused the personalisation purposes is still shown ads keyed to the identifier for
+    /// frequency capping and cross-app reporting, which is what ATT actually gates.
+    ///
+    /// True where the keys are absent: outside the TCF regions the identifier is used as it
+    /// always was.
+    var adsMayUseAdvertisingIdentifier: Bool {
+        guard let purposeConsents = UserDefaults.standard.string(forKey: "IABTCF_PurposeConsents") else {
+            return true
+        }
+
+        return purposeConsents.first == "1"
     }
 
     /// Whether this user has a consent choice worth reopening.
@@ -115,7 +139,7 @@ final class ConsentManager {
         let canRequestAds = ConsentInformation.shared.canRequestAds
 
         if !canRequestAds {
-            CrashManager.shared.log("consent does not allow personalised or non-personalised ads; limited ads only")
+            CrashManager.shared.log("no consent gathered; not requesting an ad")
         }
 
         DispatchQueue.main.async {

--- a/OpenDocumentReader/ConsentManager.swift
+++ b/OpenDocumentReader/ConsentManager.swift
@@ -35,22 +35,15 @@ final class ConsentManager {
     ///
     /// The completion runs on the main queue.
     func gatherConsent(from viewController: UIViewController, completion: @escaping (Bool) -> Void) {
-        let parameters = RequestParameters()
-        parameters.isTaggedForUnderAgeOfConsent = false
-
-        ConsentInformation.shared.requestConsentInfoUpdate(with: parameters) { requestError in
-            if let requestError = requestError {
-                // fires for the mundane offline case too - a device that was asleep
-                // times out against fundingchoicesmessages.google.com
-                print("consent info update failed: \(requestError.localizedDescription)")
-
+        requestUpdate { updated in
+            guard updated else {
                 self.finish(completion)
                 return
             }
 
             ConsentForm.loadAndPresentIfRequired(from: viewController) { formError in
                 if let formError = formError {
-                    print("consent form failed: \(formError.localizedDescription)")
+                    CrashManager.shared.log("consent form failed: \(formError.localizedDescription)")
                 }
 
                 self.finish(completion)
@@ -58,11 +51,71 @@ final class ConsentManager {
         }
     }
 
+    /// Brings consent up to date without ever presenting a form.
+    ///
+    /// Runs on every launch from the document browser, because `privacyOptionsRequirementStatus`
+    /// and `canRequestAds` answer from a cache that is only filled by an update completing in the
+    /// *current* session. Skip it and the privacy entry point disappears on the second launch.
+    ///
+    /// The completion runs on the main queue.
+    func refresh(completion: @escaping () -> Void) {
+        requestUpdate { _ in
+            DispatchQueue.main.async {
+                completion()
+            }
+        }
+    }
+
+    /// Whether this user has a consent choice worth reopening.
+    ///
+    /// False outside the regions where a form is configured at all - there is nothing to show, so
+    /// the entry point offering it should not be there either.
+    var privacyOptionsRequired: Bool {
+        ConsentInformation.shared.privacyOptionsRequirementStatus == .required
+    }
+
+    /// Reopens the consent form so a decision can be changed or withdrawn.
+    ///
+    /// GDPR Art. 7(3) wants withdrawing consent to be as easy as giving it, and TCF requires the
+    /// CMP to be reachable again. Only call this in response to the user asking for it.
+    ///
+    /// The completion runs on the main queue.
+    func presentPrivacyOptions(from viewController: UIViewController, completion: @escaping () -> Void) {
+        ConsentForm.presentPrivacyOptionsForm(from: viewController) { formError in
+            if let formError = formError {
+                CrashManager.shared.log("privacy options form failed: \(formError.localizedDescription)")
+            }
+
+            DispatchQueue.main.async {
+                completion()
+            }
+        }
+    }
+
+    /// Reports whether the update succeeded; a failure is logged, never treated as a refusal.
+    private func requestUpdate(_ completion: @escaping (Bool) -> Void) {
+        let parameters = RequestParameters()
+        parameters.isTaggedForUnderAgeOfConsent = false
+
+        ConsentInformation.shared.requestConsentInfoUpdate(with: parameters) { requestError in
+            if let requestError = requestError {
+                // fires for the mundane offline case too - a device that was asleep
+                // times out against fundingchoicesmessages.google.com
+                CrashManager.shared.log("consent info update failed: \(requestError.localizedDescription)")
+
+                completion(false)
+                return
+            }
+
+            completion(true)
+        }
+    }
+
     private func finish(_ completion: @escaping (Bool) -> Void) {
         let canRequestAds = ConsentInformation.shared.canRequestAds
 
         if !canRequestAds {
-            print("consent does not allow requesting ads")
+            CrashManager.shared.log("consent does not allow personalised or non-personalised ads; limited ads only")
         }
 
         DispatchQueue.main.async {

--- a/OpenDocumentReader/ConsentManager.swift
+++ b/OpenDocumentReader/ConsentManager.swift
@@ -10,34 +10,23 @@ import UserMessagingPlatform
 
 /// The consent form in front of the banner in the Lite configuration.
 ///
-/// Google's EU user consent policy requires a certified CMP, integrated with IAB TCF, for traffic
-/// from the EEA, the UK and Switzerland. UMP is Google's own, and it is what the Android app has
-/// used since it shipped its privacy messaging.
-///
-/// Which users are asked is decided by UMP, not here: the messages are geo-targeted in AdMob under
-/// Privacy & messaging, and the SDK resolves the user's region server-side. Outside a configured
-/// region nothing is presented and `canRequestAds` is simply true.
+/// Google's EU user consent policy requires a TCF-integrated CMP for the EEA, the UK and
+/// Switzerland; UMP is Google's own, and what the Android app uses. Who is asked is decided by the
+/// geo-targeting of the messages in AdMob, not here.
 final class ConsentManager {
 
     static let manager = ConsentManager()
 
     private init() {}
 
-    /// Brings consent up to date, presenting the form if the user's region requires one, and then
-    /// reports whether an ad may be requested.
+    /// Brings consent up to date, presenting the form where the region requires one.
     ///
-    /// Whether we may load an ad is `canRequestAds` and nothing else - never whether the calls
-    /// themselves came back clean. The SDK caches the user's decision, so a form that fails to
-    /// present, or an update that times out because the device is offline, still leaves an earlier
-    /// consent standing, and outside the regions where a form is required at all there is no
-    /// decision to fail in the first place. Treating those errors as a refusal would hide the
-    /// banner from users who had already said yes.
+    /// Reports `canRequestAds`: whether an answer is on file, not what it was - "do not consent"
+    /// leaves it true. What the answer allows is `adsMayUseAdvertisingIdentifier`. Errors do not
+    /// enter into it; the decision is cached, so a failed form or an offline update still leaves
+    /// an earlier consent standing.
     ///
-    /// It is not a report of what the user chose, either: the property says only that an answer
-    /// has been gathered, and "do not consent" is an answer. What that answer allows is
-    /// `adsMayUseAdvertisingIdentifier` below.
-    ///
-    /// The completion runs on the main queue.
+    /// Completes on the main queue.
     func gatherConsent(from viewController: UIViewController, completion: @escaping (Bool) -> Void) {
         requestUpdate { updated in
             guard updated else {
@@ -57,11 +46,11 @@ final class ConsentManager {
 
     /// Brings consent up to date without ever presenting a form.
     ///
-    /// Runs on every launch from the document browser, because `privacyOptionsRequirementStatus`
-    /// and `canRequestAds` answer from a cache that is only filled by an update completing in the
-    /// *current* session. Skip it and the privacy entry point disappears on the second launch.
+    /// Needed on every launch: `privacyOptionsRequirementStatus` answers from a cache only an
+    /// update in the *current* session fills, so skipping it hides the privacy entry point on the
+    /// second launch.
     ///
-    /// The completion runs on the main queue.
+    /// Completes on the main queue.
     func refresh(completion: @escaping () -> Void) {
         requestUpdate { _ in
             DispatchQueue.main.async {
@@ -70,18 +59,13 @@ final class ConsentManager {
         }
     }
 
-    /// Whether an ad shown to this user may carry an advertising identifier, and so whether ATT
-    /// has anything to govern.
+    /// Whether an ad shown to this user may carry an advertising identifier, which is what ATT
+    /// governs.
     ///
-    /// The CMP writes the TCF signals into `UserDefaults`, as the framework requires. The first
-    /// flag of `IABTCF_PurposeConsents` is purpose 1, storing and reading information on the
-    /// device; without it Google can serve neither personalised nor non-personalised ads and falls
-    /// back to limited ads, which carry no identifier at all. A user who allowed purpose 1 and
-    /// refused the personalisation purposes is still shown ads keyed to the identifier for
-    /// frequency capping and cross-app reporting, which is what ATT actually gates.
-    ///
-    /// True where the keys are absent: outside the TCF regions the identifier is used as it
-    /// always was.
+    /// The first flag of the TCF signals UMP writes to `UserDefaults` is purpose 1, device storage.
+    /// Without it Google falls back to limited ads, which carry no identifier; refusing only
+    /// personalisation leaves one in play, for frequency capping and cross-app reporting. Absent
+    /// keys mean no TCF region.
     var adsMayUseAdvertisingIdentifier: Bool {
         guard let purposeConsents = UserDefaults.standard.string(forKey: "IABTCF_PurposeConsents") else {
             return true
@@ -90,20 +74,16 @@ final class ConsentManager {
         return purposeConsents.first == "1"
     }
 
-    /// Whether this user has a consent choice worth reopening.
-    ///
-    /// False outside the regions where a form is configured at all - there is nothing to show, so
-    /// the entry point offering it should not be there either.
+    /// Whether this user has a consent choice worth reopening. False where no message is
+    /// configured: nothing to show, so no entry point either.
     var privacyOptionsRequired: Bool {
         ConsentInformation.shared.privacyOptionsRequirementStatus == .required
     }
 
-    /// Reopens the consent form so a decision can be changed or withdrawn.
+    /// Reopens the consent form so a decision can be changed or withdrawn, as GDPR Art. 7(3) and
+    /// TCF require. Only in response to the user asking.
     ///
-    /// GDPR Art. 7(3) wants withdrawing consent to be as easy as giving it, and TCF requires the
-    /// CMP to be reachable again. Only call this in response to the user asking for it.
-    ///
-    /// The completion runs on the main queue.
+    /// Completes on the main queue.
     func presentPrivacyOptions(from viewController: UIViewController, completion: @escaping () -> Void) {
         ConsentForm.presentPrivacyOptionsForm(from: viewController) { formError in
             if let formError = formError {
@@ -123,8 +103,7 @@ final class ConsentManager {
 
         ConsentInformation.shared.requestConsentInfoUpdate(with: parameters) { requestError in
             if let requestError = requestError {
-                // fires for the mundane offline case too - a device that was asleep
-                // times out against fundingchoicesmessages.google.com
+                // offline is the mundane case, timing out against fundingchoicesmessages.google.com
                 CrashManager.shared.log("consent info update failed: \(requestError.localizedDescription)")
 
                 completion(false)

--- a/OpenDocumentReader/ConsentManager.swift
+++ b/OpenDocumentReader/ConsentManager.swift
@@ -1,0 +1,72 @@
+/*
+See LICENSE folder for this sample’s licensing information.
+
+Abstract:
+Gathers advertising consent through Google's User Messaging Platform.
+*/
+
+import UIKit
+import UserMessagingPlatform
+
+/// The consent form in front of the banner in the Lite configuration.
+///
+/// Google's EU user consent policy requires a certified CMP, integrated with IAB TCF, for traffic
+/// from the EEA, the UK and Switzerland. UMP is Google's own, and it is what the Android app has
+/// used since it shipped its privacy messaging.
+///
+/// Which users are asked is decided by UMP, not here: the messages are geo-targeted in AdMob under
+/// Privacy & messaging, and the SDK resolves the user's region server-side. Outside a configured
+/// region nothing is presented and `canRequestAds` is simply true.
+final class ConsentManager {
+
+    static let manager = ConsentManager()
+
+    private init() {}
+
+    /// Brings consent up to date, presenting the form if the user's region requires one, and then
+    /// reports whether an ad may be requested.
+    ///
+    /// Whether we may load an ad is `canRequestAds` and nothing else - never whether the calls
+    /// themselves came back clean. The SDK caches the user's decision, so a form that fails to
+    /// present, or an update that times out because the device is offline, still leaves an earlier
+    /// consent standing, and outside the regions where a form is required at all there is no
+    /// decision to fail in the first place. Treating those errors as a refusal would hide the
+    /// banner from users who had already said yes.
+    ///
+    /// The completion runs on the main queue.
+    func gatherConsent(from viewController: UIViewController, completion: @escaping (Bool) -> Void) {
+        let parameters = RequestParameters()
+        parameters.isTaggedForUnderAgeOfConsent = false
+
+        ConsentInformation.shared.requestConsentInfoUpdate(with: parameters) { requestError in
+            if let requestError = requestError {
+                // fires for the mundane offline case too - a device that was asleep
+                // times out against fundingchoicesmessages.google.com
+                print("consent info update failed: \(requestError.localizedDescription)")
+
+                self.finish(completion)
+                return
+            }
+
+            ConsentForm.loadAndPresentIfRequired(from: viewController) { formError in
+                if let formError = formError {
+                    print("consent form failed: \(formError.localizedDescription)")
+                }
+
+                self.finish(completion)
+            }
+        }
+    }
+
+    private func finish(_ completion: @escaping (Bool) -> Void) {
+        let canRequestAds = ConsentInformation.shared.canRequestAds
+
+        if !canRequestAds {
+            print("consent does not allow requesting ads")
+        }
+
+        DispatchQueue.main.async {
+            completion(canRequestAds)
+        }
+    }
+}

--- a/OpenDocumentReader/DocumentBrowserViewController.swift
+++ b/OpenDocumentReader/DocumentBrowserViewController.swift
@@ -53,7 +53,7 @@ class DocumentBrowserViewController: UIDocumentBrowserViewController, UIDocument
 
         ConsentManager.manager.refresh {
             let item = UIBarButtonItem(
-                title: NSLocalizedString("privacy", comment: ""),
+                title: NSLocalizedString("privacy", value: "Privacy", comment: ""),
                 style: .plain,
                 target: self,
                 action: #selector(self.showPrivacyOptions(_:))
@@ -65,19 +65,25 @@ class DocumentBrowserViewController: UIDocumentBrowserViewController, UIDocument
 
     @objc private func showPrivacyOptions(_ sender: UIBarButtonItem) {
         let sheet = UIAlertController(
-            title: NSLocalizedString("privacy", comment: ""), message: nil, preferredStyle: .actionSheet)
+            title: NSLocalizedString("privacy", value: "Privacy", comment: ""), message: nil,
+            preferredStyle: .actionSheet)
 
         // absent outside the regions UMP has a message configured for, where there is no
         // decision on file and nothing for the form to show
         if ConsentManager.manager.privacyOptionsRequired {
             sheet.addAction(
-                UIAlertAction(title: NSLocalizedString("privacy_ad_choices", comment: ""), style: .default) { _ in
+                UIAlertAction(
+                    title: NSLocalizedString("privacy_ad_choices", value: "Ad privacy choices", comment: ""),
+                    style: .default
+                ) { _ in
                     ConsentManager.manager.presentPrivacyOptions(from: self) {}
                 })
         }
 
         sheet.addAction(
-            UIAlertAction(title: NSLocalizedString("privacy_tracking", comment: ""), style: .default) { _ in
+            UIAlertAction(
+                title: NSLocalizedString("privacy_tracking", value: "Tracking permission", comment: ""), style: .default
+            ) { _ in
                 self.showTrackingPermissionHint()
             })
 
@@ -92,13 +98,19 @@ class DocumentBrowserViewController: UIDocumentBrowserViewController, UIDocument
     /// ATT cannot be asked twice, so the only way back is the Settings app.
     private func showTrackingPermissionHint() {
         let alert = UIAlertController(
-            title: NSLocalizedString("privacy_tracking", comment: ""),
-            message: NSLocalizedString("privacy_tracking_message", comment: ""),
+            title: NSLocalizedString("privacy_tracking", value: "Tracking permission", comment: ""),
+            message: NSLocalizedString(
+                "privacy_tracking_message",
+                value:
+                    "iOS asks for tracking permission once. You can change it any time in Settings, under Privacy & Security → Tracking. Changing it there closes the app.",
+                comment: ""),
             preferredStyle: .alert
         )
 
         alert.addAction(
-            UIAlertAction(title: NSLocalizedString("privacy_open_settings", comment: ""), style: .default) { _ in
+            UIAlertAction(
+                title: NSLocalizedString("privacy_open_settings", value: "Open Settings", comment: ""), style: .default
+            ) { _ in
                 guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
 
                 UIApplication.shared.open(url)

--- a/OpenDocumentReader/DocumentBrowserViewController.swift
+++ b/OpenDocumentReader/DocumentBrowserViewController.swift
@@ -26,8 +26,7 @@ class DocumentBrowserViewController: UIDocumentBrowserViewController, UIDocument
 
         StoreReviewHelper.checkAndAskForReview()
 
-        // ahead of the intro guard below: this has to run on every launch, and most launches
-        // return there
+        // ahead of the intro guard below, which most launches return at
         refreshPrivacyButton()
 
         let userDefaults = UserDefaults.standard
@@ -43,11 +42,10 @@ class DocumentBrowserViewController: UIDocumentBrowserViewController, UIDocument
 
     // MARK: - Privacy
 
-    /// Brings consent up to date and then shows or hides the entry point that reopens it.
+    /// Brings consent up to date and then offers the way back to it.
     ///
-    /// The app has no settings screen, so the browser's own chrome carries this. It is the only
-    /// route back to either choice: the consent form is shown once, and ATT is one-shot per
-    /// install.
+    /// The app has no settings screen, so the browser's chrome carries this - the only route back
+    /// to either choice, both of which are asked once.
     private func refreshPrivacyButton() {
         guard ConfigurationManager.manager.configuration == .lite else { return }
 
@@ -68,8 +66,7 @@ class DocumentBrowserViewController: UIDocumentBrowserViewController, UIDocument
             title: NSLocalizedString("privacy", value: "Privacy", comment: ""), message: nil,
             preferredStyle: .actionSheet)
 
-        // absent outside the regions UMP has a message configured for, where there is no
-        // decision on file and nothing for the form to show
+        // absent where UMP has no message configured, and so nothing to show
         if ConsentManager.manager.privacyOptionsRequired {
             sheet.addAction(
                 UIAlertAction(

--- a/OpenDocumentReader/DocumentBrowserViewController.swift
+++ b/OpenDocumentReader/DocumentBrowserViewController.swift
@@ -26,6 +26,10 @@ class DocumentBrowserViewController: UIDocumentBrowserViewController, UIDocument
 
         StoreReviewHelper.checkAndAskForReview()
 
+        // ahead of the intro guard below: this has to run on every launch, and most launches
+        // return there
+        refreshPrivacyButton()
+
         let userDefaults = UserDefaults.standard
         let wasIntroWatched = userDefaults.bool(forKey: Constants.key_was_intro_watched)
 
@@ -35,6 +39,74 @@ class DocumentBrowserViewController: UIDocumentBrowserViewController, UIDocument
         {
             present(pageVC, animated: true, completion: nil)
         }
+    }
+
+    // MARK: - Privacy
+
+    /// Brings consent up to date and then shows or hides the entry point that reopens it.
+    ///
+    /// The app has no settings screen, so the browser's own chrome carries this. It is the only
+    /// route back to either choice: the consent form is shown once, and ATT is one-shot per
+    /// install.
+    private func refreshPrivacyButton() {
+        guard ConfigurationManager.manager.configuration == .lite else { return }
+
+        ConsentManager.manager.refresh {
+            let item = UIBarButtonItem(
+                title: NSLocalizedString("privacy", comment: ""),
+                style: .plain,
+                target: self,
+                action: #selector(self.showPrivacyOptions(_:))
+            )
+
+            self.additionalTrailingNavigationBarButtonItems = [item]
+        }
+    }
+
+    @objc private func showPrivacyOptions(_ sender: UIBarButtonItem) {
+        let sheet = UIAlertController(
+            title: NSLocalizedString("privacy", comment: ""), message: nil, preferredStyle: .actionSheet)
+
+        // absent outside the regions UMP has a message configured for, where there is no
+        // decision on file and nothing for the form to show
+        if ConsentManager.manager.privacyOptionsRequired {
+            sheet.addAction(
+                UIAlertAction(title: NSLocalizedString("privacy_ad_choices", comment: ""), style: .default) { _ in
+                    ConsentManager.manager.presentPrivacyOptions(from: self) {}
+                })
+        }
+
+        sheet.addAction(
+            UIAlertAction(title: NSLocalizedString("privacy_tracking", comment: ""), style: .default) { _ in
+                self.showTrackingPermissionHint()
+            })
+
+        sheet.addAction(UIAlertAction(title: NSLocalizedString("cancel", comment: ""), style: .cancel))
+
+        // an action sheet without this crashes on iPad, where it is a popover
+        sheet.popoverPresentationController?.barButtonItem = sender
+
+        present(sheet, animated: true)
+    }
+
+    /// ATT cannot be asked twice, so the only way back is the Settings app.
+    private func showTrackingPermissionHint() {
+        let alert = UIAlertController(
+            title: NSLocalizedString("privacy_tracking", comment: ""),
+            message: NSLocalizedString("privacy_tracking_message", comment: ""),
+            preferredStyle: .alert
+        )
+
+        alert.addAction(
+            UIAlertAction(title: NSLocalizedString("privacy_open_settings", comment: ""), style: .default) { _ in
+                guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
+
+                UIApplication.shared.open(url)
+            })
+
+        alert.addAction(UIAlertAction(title: NSLocalizedString("cancel", comment: ""), style: .cancel))
+
+        present(alert, animated: true)
     }
 
     func documentBrowser(

--- a/OpenDocumentReader/DocumentViewController.swift
+++ b/OpenDocumentReader/DocumentViewController.swift
@@ -159,12 +159,21 @@ class DocumentViewController: UIViewController, DocumentDelegate, BannerViewDele
 
         ConsentManager.manager.gatherConsent(from: self) { canRequestAds in
             guard canRequestAds else {
-                // Refused, but still worth asking for: the "do not consent" answer emits a TC
-                // string carrying the special purposes, from which Google selects limited ads
-                // server-side - no cookies, no identifiers, no local storage. Showing nothing
-                // here would be stricter than the rules require and costs the fill outright.
+                // No answer on file at all - the form could not be presented, or a first launch
+                // in a region that requires one came up offline. This is not the refusal path:
+                // "do not consent" is still an answer, and leaves this true. With no consent
+                // signal to send, no ad may be requested; a later launch will gather one.
+                self.hideBannerView()
+                return
+            }
+
+            guard ConsentManager.manager.adsMayUseAdvertisingIdentifier else {
+                // Refused, but still worth serving: the answer emits a TC string carrying the
+                // special purposes, from which Google selects limited ads server-side - no
+                // identifiers, no personalisation. Showing nothing here would be stricter than
+                // the rules require and costs the fill outright.
                 //
-                // No ATT on this path. Limited ads use no advertising identifier, so there is
+                // No ATT on this path. A limited ad uses no advertising identifier, so there is
                 // nothing for Apple's question to govern and asking it would contradict the
                 // answer the user just gave.
                 self.loadBannerAd()

--- a/OpenDocumentReader/DocumentViewController.swift
+++ b/OpenDocumentReader/DocumentViewController.swift
@@ -159,13 +159,25 @@ class DocumentViewController: UIViewController, DocumentDelegate, BannerViewDele
 
         ConsentManager.manager.gatherConsent(from: self) { canRequestAds in
             guard canRequestAds else {
-                self.hideBannerView()
+                // Refused, but still worth asking for: the "do not consent" answer emits a TC
+                // string carrying the special purposes, from which Google selects limited ads
+                // server-side - no cookies, no identifiers, no local storage. Showing nothing
+                // here would be stricter than the rules require and costs the fill outright.
+                //
+                // No ATT on this path. Limited ads use no advertising identifier, so there is
+                // nothing for Apple's question to govern and asking it would contradict the
+                // answer the user just gave.
+                self.loadBannerAd()
                 return
             }
 
             // ATT is Apple's separate question about the IDFA and does not stand in for
             // consent under the EU rules. It is only worth putting in front of someone who
             // is going to be shown an ad at all, so it follows the consent form.
+            //
+            // Asked even when the user allowed storage but refused personalisation: a
+            // non-personalised ad still uses the identifier for frequency capping and
+            // aggregated reporting across apps, which is what ATT actually gates.
             ATTrackingManager.requestTrackingAuthorization(completionHandler: { _ in
                 DispatchQueue.main.async {
                     self.loadBannerAd()

--- a/OpenDocumentReader/DocumentViewController.swift
+++ b/OpenDocumentReader/DocumentViewController.swift
@@ -148,10 +148,8 @@ class DocumentViewController: UIViewController, DocumentDelegate, BannerViewDele
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
-        // the consent form is presented modally, so it has to wait until this controller
-        // is actually in the window hierarchy - viewWillAppear is too early. Both this and
-        // viewWillAppear run again on every reappearance; the ask itself is once per
-        // controller, and UMP only presents a form when it still needs an answer.
+        // the form is modal, so it has to wait for the window hierarchy - viewWillAppear is
+        // too early. This runs again on every reappearance, hence the flag.
         guard ConfigurationManager.manager.configuration == .lite, !hasGatheredConsent else {
             return
         }
@@ -159,34 +157,22 @@ class DocumentViewController: UIViewController, DocumentDelegate, BannerViewDele
 
         ConsentManager.manager.gatherConsent(from: self) { canRequestAds in
             guard canRequestAds else {
-                // No answer on file at all - the form could not be presented, or a first launch
-                // in a region that requires one came up offline. This is not the refusal path:
-                // "do not consent" is still an answer, and leaves this true. With no consent
-                // signal to send, no ad may be requested; a later launch will gather one.
+                // nothing on file - the form failed, or a first launch offline where one is
+                // required. Not refusal: "do not consent" is an answer and leaves this true.
                 self.hideBannerView()
                 return
             }
 
             guard ConsentManager.manager.adsMayUseAdvertisingIdentifier else {
-                // Refused, but still worth serving: the answer emits a TC string carrying the
-                // special purposes, from which Google selects limited ads server-side - no
-                // identifiers, no personalisation. Showing nothing here would be stricter than
-                // the rules require and costs the fill outright.
-                //
-                // No ATT on this path. A limited ad uses no advertising identifier, so there is
-                // nothing for Apple's question to govern and asking it would contradict the
-                // answer the user just gave.
+                // refused, and still worth serving: Google selects limited ads server-side from
+                // the TC string's special purposes, and showing nothing would be stricter than
+                // the rules require. No ATT - a limited ad carries no identifier to govern.
                 self.loadBannerAd()
                 return
             }
 
-            // ATT is Apple's separate question about the IDFA and does not stand in for
-            // consent under the EU rules. It is only worth putting in front of someone who
-            // is going to be shown an ad at all, so it follows the consent form.
-            //
-            // Asked even when the user allowed storage but refused personalisation: a
-            // non-personalised ad still uses the identifier for frequency capping and
-            // aggregated reporting across apps, which is what ATT actually gates.
+            // ATT asks about the IDFA and is no substitute for consent under the EU rules, so
+            // it follows the form, and only for users who get an ad.
             ATTrackingManager.requestTrackingAuthorization(completionHandler: { _ in
                 DispatchQueue.main.async {
                     self.loadBannerAd()

--- a/OpenDocumentReader/DocumentViewController.swift
+++ b/OpenDocumentReader/DocumentViewController.swift
@@ -18,6 +18,7 @@ class DocumentViewController: UIViewController, DocumentDelegate, BannerViewDele
 {
 
     private var browserTransition: DocumentBrowserTransitioningDelegate?
+    private var hasGatheredConsent = false
     public var transitionController: UIDocumentBrowserTransitionController? {
         didSet {
             if let controller = transitionController {
@@ -139,14 +140,37 @@ class DocumentViewController: UIViewController, DocumentDelegate, BannerViewDele
             bannerView.delegate = self
             bannerView.adUnitID = "ca-app-pub-8161473686436957/8123543897"
             bannerView.rootViewController = self
+        } else {
+            hideBannerView()
+        }
+    }
 
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        // the consent form is presented modally, so it has to wait until this controller
+        // is actually in the window hierarchy - viewWillAppear is too early. Both this and
+        // viewWillAppear run again on every reappearance; the ask itself is once per
+        // controller, and UMP only presents a form when it still needs an answer.
+        guard ConfigurationManager.manager.configuration == .lite, !hasGatheredConsent else {
+            return
+        }
+        hasGatheredConsent = true
+
+        ConsentManager.manager.gatherConsent(from: self) { canRequestAds in
+            guard canRequestAds else {
+                self.hideBannerView()
+                return
+            }
+
+            // ATT is Apple's separate question about the IDFA and does not stand in for
+            // consent under the EU rules. It is only worth putting in front of someone who
+            // is going to be shown an ad at all, so it follows the consent form.
             ATTrackingManager.requestTrackingAuthorization(completionHandler: { _ in
                 DispatchQueue.main.async {
                     self.loadBannerAd()
                 }
             })
-        } else {
-            hideBannerView()
         }
     }
 
@@ -190,10 +214,6 @@ class DocumentViewController: UIViewController, DocumentDelegate, BannerViewDele
 
     func bannerView(_ bannerView: BannerView, didFailToReceiveAdWithError error: Error) {
         hideBannerView()
-    }
-
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
     }
 
     override func viewDidDisappear(_ animated: Bool) {

--- a/OpenDocumentReader/en.lproj/Localizable.strings
+++ b/OpenDocumentReader/en.lproj/Localizable.strings
@@ -77,3 +77,18 @@
 "intro_next" = "Next";
 "intro_skip" = "Skip";
 "intro_start" = "Start";
+
+/* Entry point in the document browser that reopens the advertising consent choices */
+"privacy" = "Privacy";
+
+/* Reopens the Google UMP consent form */
+"privacy_ad_choices" = "Ad privacy choices";
+
+/* Leads to the iOS tracking permission for this app */
+"privacy_tracking" = "Tracking permission";
+
+/* Explains that ATT is asked once per install and lives in iOS Settings afterwards */
+"privacy_tracking_message" = "iOS asks for tracking permission once. You can change it any time in Settings, under Privacy & Security → Tracking. Changing it there closes the app.";
+
+/* Opens this app's page in the Settings app */
+"privacy_open_settings" = "Open Settings";


### PR DESCRIPTION
The Lite app serves ads to EEA/UK/CH users with **no CMP**. ATT is not a substitute: it is Apple's question about the IDFA, and it does not satisfy Google's EU user consent policy, which has required a TCF-integrated CMP since Jan 2024. Android has had this since Dec 2023.

## What it does

- Links **GoogleUserMessagingPlatform** and adds `ConsentManager`, shaped like the Android `AdManager` flow.
- Consent form first, **ATT after** — and only for users who will see an ad.
- Ad setup moves to `viewDidAppear`; the form is modal, so `viewWillAppear` is too early.
- Whether an ad may load is `canRequestAds` **and nothing else**, never whether the calls came back clean — cached consent must survive an offline update.
- No answer on file, **no ad**: a form that failed to present, or a first launch in a required region that came up offline, leaves nothing to serve against and the banner stays away.

**On refusal the banner still loads.** "Do not consent" emits a TC string whose special purposes let Google select **limited ads** server-side: no identifiers, no personalisation. Serving nothing there is stricter than required and gives up the fill. ATT is skipped on that path — a limited ad uses no identifier for it to govern.

Note that refusal is *not* `canRequestAds == false`. That property reports only that an answer was gathered, and "do not consent" is an answer ([the SDK team is explicit](https://groups.google.com/g/google-admob-ads-sdk/c/Dydp-cWcOIo): UMP "deals with consent management only, and does not provide ad service status"). What the answer allows is read from the TCF signals UMP writes to `UserDefaults`: purpose 1, storing and reading information on the device, is the flag below which Google can serve neither personalised nor non-personalised ads and falls back to limited ads.

That same flag decides ATT, since it is the same line — ATT *is* asked of users who allow storage but refuse personalisation: non-personalised ads still use the identifier for frequency capping and cross-app reporting, which is what ATT gates.

**Consent is also withdrawable.** GDPR Art. 7(3) and TCF both want that. There is no settings screen, so a Privacy item on the document browser offers the UMP form (only where one exists) and a route to the iOS tracking toggle. `ConsentManager.refresh()` runs a silent update per launch — `privacyOptionsRequirementStatus` is stale until an update completes in-session, so the button would otherwise vanish on the second launch.

## Before merging

- [ ] **Publish the GDPR message** in AdMob → Privacy & messaging, targeted EEA/UK/CH, for the Lite iOS app and its ad unit. Without it the SDK returns no form.
- [ ] **Turn on "Programmatic limited ads"** (AdMob → Settings → Account information). The refusal path is near-zero fill without it.
- [ ] Consider a US states (CCPA/CPRA) message.
- [ ] Legal read on serving limited ads without consent.

## Testing

Both schemes build (`BUILD SUCCEEDED`), `scripts/format.sh --check` passes. **Not yet run on a device** — no message is published, so the form has never appeared. Worth checking with `ConsentDebugSettings` / `DEBUG_GEOGRAPHY_EEA`:

| Scenario | Expected |
|---|---|
| Accept all | form → ATT → banner |
| Accept storage, refuse personalisation | form → ATT still asked → banner |
| Refuse everything | form → no ATT → **banner still loads** |
| Accept, relaunch offline | banner loads from cache, no form |
| First launch offline, EEA | no form, no ATT, **no banner** |
| Outside EEA | no form, ATT, banner — as today |
| Second launch, EEA | Privacy button still there |
| ODR Full | no banner, no form, no button |

Expect fill rate to move in both directions once live: down as users decline personalisation, up as refusers get limited ads instead of nothing. Watch the serving-restriction dimension in AdMob.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
