### PR TITLE
Write our own ATT purpose string instead of Google's sample

### DIFF
--- a/OpenDocumentReader/Info-Lite.plist
+++ b/OpenDocumentReader/Info-Lite.plist
@@ -65,8 +65,10 @@
 	</dict>
 	<key>NSPhotoLibraryAddUsageDescription</key>
 	<string>Copy image from document to your Photos</string>
+	<!-- Not Google's sample string: it shipped in 1.37 build 44 and App Review
+	     rejected it under 5.1.1 as placeholder. Name the use, give an example. -->
 	<key>NSUserTrackingUsageDescription</key>
-	<string>This identifier will be used to deliver personalized ads to you.</string>
+	<string>Uses your device's advertising identifier to personalize the ad banner above your document — for example, office and productivity apps rather than unrelated ones. Decline and untailored ads are shown instead.</string>
 	<key>SKAdNetworkItems</key>
 	<array>
 		<dict>


### PR DESCRIPTION
1.37 build 44 was rejected under **5.1.1 Legal: Privacy** — the automated scan flagged `NSUserTrackingUsageDescription` as placeholder text. The string was Google's AdMob sample, copied verbatim in d4b054a.

```
- This identifier will be used to deliver personalized ads to you.
+ Uses your device's advertising identifier to personalize the ad banner
+ above your document — for example, office and productivity apps rather
+ than unrelated ones. Decline and untailored ads are shown instead.
```

Names the data, the use and a concrete example. Also corrects the banner's position: the constraints run `searchBar → bannerView → pageTabBar → webview`, so it sits above the document.

ATT stays, and `PrivacyInfo.xcprivacy` is untouched — `NSPrivacyTracking` false with an empty domain list, since true reopens ITMS-91064. Needs **build 45** on the existing 1.37 (Rejected, not closed, so no version bump); purpose strings live in the binary, so Resolution Center can't clear this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)