### PR TITLE
Take odrcore 6.4.0, open csv as a spreadsheet and keep the page margins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,12 +25,25 @@ once the version tag exists.
   The form is Google's own (UMP), the same one the Android app uses.
 - A "Privacy" entry in the document browser reopens that choice, and leads to
   the system tracking permission.
+- CSV files open as spreadsheets. The separator is worked out from the file,
+  quoted fields stay whole, and a value that only looks like a number is left as
+  text. They used to be handed to the web view as plain text.
 
 ### Changed
 
 - The tracking permission is asked after the consent form, and only where the
   answer allows an ad to carry an advertising identifier. Refusing consent
   leaves limited ads, which carry none, rather than no ads at all.
+- Documents keep the side margins of a printed page, which is what they were
+  written to look like.
+- The engine is odrcore 6.4.0, up from 6.2.0. Spreadsheets are drawn in a
+  quieter grid under a ruler that stays put while scrolling; a .docx breaks onto
+  the pages it was written for and its numbered lists carry their markers into a
+  copy; a document that is not UTF-8 comes out as text rather than mojibake; an
+  archive lists its entries as files; embedded PDF fonts no longer render as
+  tofu; and svg, ico, jxl, jp2, psd, wmf and emf are shown as images.
+- Edit is offered only for a document the engine holds open for editing, rather
+  than for anything it managed to render.
 
 ## [1.37]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,11 +37,9 @@ once the version tag exists.
 - Documents keep the side margins of a printed page, which is what they were
   written to look like.
 - The engine is odrcore 6.4.0, up from 6.2.0. Spreadsheets are drawn in a
-  quieter grid under a ruler that stays put while scrolling; a .docx breaks onto
-  the pages it was written for and its numbered lists carry their markers into a
-  copy; a document that is not UTF-8 comes out as text rather than mojibake; an
-  archive lists its entries as files; embedded PDF fonts no longer render as
-  tofu; and svg, ico, jxl, jp2, psd, wmf and emf are shown as images.
+  quieter grid, under a row and column ruler that stays put while scrolling, and
+  a .docx breaks onto the pages it was written for, its numbered lists carrying
+  their markers into a copy.
 - Edit is offered only for a document the engine holds open for editing, rather
   than for anything it managed to render.
 

--- a/OpenDocumentReader.xcodeproj/project.pbxproj
+++ b/OpenDocumentReader.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		E2A17B0400000000000000A4 /* PageTabBarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2A17B0300000000000000A3 /* PageTabBarTests.swift */; };
 		E2A17B1000000000000000B0 /* test.ods in Resources */ = {isa = PBXBuildFile; fileRef = E2A17B1200000000000000B2 /* test.ods */; };
 		E2A17B1100000000000000B1 /* test.odp in Resources */ = {isa = PBXBuildFile; fileRef = E2A17B1300000000000000B3 /* test.odp */; };
+		E2A17B1400000000000000B4 /* test.csv in Resources */ = {isa = PBXBuildFile; fileRef = E2A17B1500000000000000B5 /* test.csv */; };
 		E2A17B2000000000000000C0 /* CoreFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E2A17B2200000000000000C2 /* CoreFoundation.framework */; };
 		E2A17B2100000000000000C1 /* CFNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E2A17B2300000000000000C3 /* CFNetwork.framework */; };
 		E2D0B3D9226D945400534FCC /* StoreReviewHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2D0B3D8226D945400534FCC /* StoreReviewHelper.swift */; };
@@ -111,6 +112,7 @@
 		E2A17B0300000000000000A3 /* PageTabBarTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageTabBarTests.swift; sourceTree = "<group>"; };
 		E2A17B1200000000000000B2 /* test.ods */ = {isa = PBXFileReference; lastKnownFileType = file; path = test.ods; sourceTree = "<group>"; };
 		E2A17B1300000000000000B3 /* test.odp */ = {isa = PBXFileReference; lastKnownFileType = file; path = test.odp; sourceTree = "<group>"; };
+		E2A17B1500000000000000B5 /* test.csv */ = {isa = PBXFileReference; lastKnownFileType = text; path = test.csv; sourceTree = "<group>"; };
 		E2A17B2200000000000000C2 /* CoreFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreFoundation.framework; path = System/Library/Frameworks/CoreFoundation.framework; sourceTree = SDKROOT; };
 		E2A17B2300000000000000C3 /* CFNetwork.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CFNetwork.framework; path = System/Library/Frameworks/CFNetwork.framework; sourceTree = SDKROOT; };
 		E2D0B3D8226D945400534FCC /* StoreReviewHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreReviewHelper.swift; sourceTree = "<group>"; };
@@ -202,6 +204,7 @@
 				E24110232586349500800247 /* test.odt */,
 				E2A17B1200000000000000B2 /* test.ods */,
 				E2A17B1300000000000000B3 /* test.odp */,
+				E2A17B1500000000000000B5 /* test.csv */,
 				E22B252E2557F0E2001D0C52 /* OpenDocumentReaderTests.swift */,
 				E2A17B0300000000000000A3 /* PageTabBarTests.swift */,
 				E22B25302557F0E2001D0C52 /* Info.plist */,
@@ -379,6 +382,7 @@
 				E24110312586349500800247 /* test.odt in Resources */,
 				E2A17B1000000000000000B0 /* test.ods in Resources */,
 				E2A17B1100000000000000B1 /* test.odp in Resources */,
+				E2A17B1400000000000000B4 /* test.csv in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -975,7 +979,7 @@
 			repositoryURL = "https://github.com/opendocument-app/OpenDocument.core.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 6.2.0;
+				minimumVersion = 6.4.0;
 			};
 		};
 		AD584FCD41577C8CDEE974AA /* XCRemoteSwiftPackageReference "swift-package-manager-google-mobile-ads" */ = {

--- a/OpenDocumentReader.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OpenDocumentReader.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/opendocument-app/OpenDocument.core.git",
       "state" : {
-        "revision" : "72661abacff00bbcafbc142a3655f1bd075e95df",
-        "version" : "6.2.0"
+        "revision" : "a50cda610027f1c5638caf357e348aeb2f4c524c",
+        "version" : "6.4.0"
       }
     },
     {

--- a/OpenDocumentReader/CoreWrapper.swift
+++ b/OpenDocumentReader/CoreWrapper.swift
@@ -85,8 +85,9 @@ private func isCsv(_ file: DecodedFile) -> Bool { file.fileType == .commaSeparat
     @objc private(set) var pageNames: [String] = []
     @objc private(set) var pageURLs: [URL] = []
 
-    /// Whether `backTranslate` has a document to apply an edit to. False for a
-    /// csv, which is rendered from the file itself — see `isCsv`.
+    /// Whether `backTranslate` has a document to apply an edit to — only a
+    /// document that said it can take one is kept, so having it *is* the answer.
+    /// False for a csv, which is rendered from the file itself — see `isCsv`.
     @objc var isEditable: Bool { lock.withLock { document != nil } }
 
     private var document: OdrCoreObjC.Document?
@@ -149,7 +150,10 @@ private func isCsv(_ file: DecodedFile) -> Bool { file.fileType == .commaSeparat
             let document = try documentFile.document()
 
             documentType = documentFile.documentType
-            openedDocument = document
+            // the document's own answer, not "we managed to open one": a format
+            // odrcore renders but cannot write back — a .doc, say — would
+            // otherwise offer Edit and fail at the save
+            openedDocument = document.isEditable && document.isSavable ? document : nil
             service = try HtmlTranslator.translate(
                 document: document, cachePath: cachePath, config: config)
         } else {

--- a/OpenDocumentReader/CoreWrapper.swift
+++ b/OpenDocumentReader/CoreWrapper.swift
@@ -76,18 +76,14 @@ private func selectViews(_ views: [HtmlView], _ documentType: DocumentType) -> [
 
 /// A csv is a *text* file to odrcore that also loads as a spreadsheet, so it
 /// answers `isDocumentFile` with false and `asDocumentFile()` fails on it.
-/// Translating the decoded file rather than a document is what reaches its
-/// table; the cost is that `backTranslate` has no document to edit, which a csv
-/// has nothing to offer anyway.
 private func isCsv(_ file: DecodedFile) -> Bool { file.fileType == .commaSeparatedValues }
 
 @objc final class CoreWrapper: NSObject {
     @objc private(set) var pageNames: [String] = []
     @objc private(set) var pageURLs: [URL] = []
 
-    /// Whether `backTranslate` has a document to apply an edit to — only a
-    /// document that said it can take one is kept, so having it *is* the answer.
-    /// False for a csv, which is rendered from the file itself — see `isCsv`.
+    /// Whether `backTranslate` has a document to apply an edit to. Only a
+    /// document that said it takes one is kept, so having it *is* the answer.
     @objc var isEditable: Bool { lock.withLock { document != nil } }
 
     private var document: OdrCoreObjC.Document?
@@ -137,8 +133,7 @@ private func isCsv(_ file: DecodedFile) -> Bool { file.fileType == .commaSeparat
         // resource paths are resolved relative to an output directory, and in
         // server mode there is none — odrcore rejects the combination
         config.relativeResourcePaths = false
-        // the side margins of a printed page, which is what the document was
-        // written to look like
+        // the side margins of a printed page, which is what it was written to look like
         config.textDocumentMargin = true
 
         let documentType: DocumentType
@@ -150,16 +145,14 @@ private func isCsv(_ file: DecodedFile) -> Bool { file.fileType == .commaSeparat
             let document = try documentFile.document()
 
             documentType = documentFile.documentType
-            // the document's own answer, not "we managed to open one": a format
-            // odrcore renders but cannot write back — a .doc, say — would
-            // otherwise offer Edit and fail at the save
+            // the document's own answer: a format odrcore renders but cannot write
+            // back would otherwise offer Edit and fail at the save
             openedDocument = document.isEditable && document.isSavable ? document : nil
             service = try HtmlTranslator.translate(
                 document: document, cachePath: cachePath, config: config)
         } else {
-            // not `.spreadsheet`, though a csv is one: that would ask for a tab
-            // per sheet, and a csv's single sheet is called "csv". The combined
-            // view holds the same table without a tab bar naming it.
+            // not `.spreadsheet`, though a csv is one: that asks for a tab per
+            // sheet, and a csv's single sheet is called "csv"
             documentType = .unknown
             openedDocument = nil
             service = try HtmlTranslator.translate(

--- a/OpenDocumentReader/CoreWrapper.swift
+++ b/OpenDocumentReader/CoreWrapper.swift
@@ -74,9 +74,20 @@ private func selectViews(_ views: [HtmlView], _ documentType: DocumentType) -> [
     }
 }
 
+/// A csv is a *text* file to odrcore that also loads as a spreadsheet, so it
+/// answers `isDocumentFile` with false and `asDocumentFile()` fails on it.
+/// Translating the decoded file rather than a document is what reaches its
+/// table; the cost is that `backTranslate` has no document to edit, which a csv
+/// has nothing to offer anyway.
+private func isCsv(_ file: DecodedFile) -> Bool { file.fileType == .commaSeparatedValues }
+
 @objc final class CoreWrapper: NSObject {
     @objc private(set) var pageNames: [String] = []
     @objc private(set) var pageURLs: [URL] = []
+
+    /// Whether `backTranslate` has a document to apply an edit to. False for a
+    /// csv, which is rendered from the file itself — see `isCsv`.
+    @objc var isEditable: Bool { lock.withLock { document != nil } }
 
     private var document: OdrCoreObjC.Document?
     private let lock = NSRecursiveLock()
@@ -116,22 +127,40 @@ private func selectViews(_ views: [HtmlView], _ documentType: DocumentType) -> [
             }
         }
 
-        guard file.isDocumentFile else {
+        guard file.isDocumentFile || isCsv(file) else {
             throw coreWrapperError(.unsupportedFileType, "not a document file")
         }
-
-        let documentFile = try file.asDocumentFile()
-        let documentType = documentFile.documentType
-        let document = try documentFile.document()
 
         let config = HtmlConfig()
         config.editable = editable
         // resource paths are resolved relative to an output directory, and in
         // server mode there is none — odrcore rejects the combination
         config.relativeResourcePaths = false
+        // the side margins of a printed page, which is what the document was
+        // written to look like
+        config.textDocumentMargin = true
 
-        let service = try HtmlTranslator.translate(
-            document: document, cachePath: cachePath, config: config)
+        let documentType: DocumentType
+        let openedDocument: OdrCoreObjC.Document?
+        let service: HtmlService
+
+        if file.isDocumentFile {
+            let documentFile = try file.asDocumentFile()
+            let document = try documentFile.document()
+
+            documentType = documentFile.documentType
+            openedDocument = document
+            service = try HtmlTranslator.translate(
+                document: document, cachePath: cachePath, config: config)
+        } else {
+            // not `.spreadsheet`, though a csv is one: that would ask for a tab
+            // per sheet, and a csv's single sheet is called "csv". The combined
+            // view holds the same table without a tab bar naming it.
+            documentType = .unknown
+            openedDocument = nil
+            service = try HtmlTranslator.translate(
+                file: file, cachePath: cachePath, config: config)
+        }
 
         let views = selectViews(service.views, documentType)
         guard !views.isEmpty else {
@@ -144,7 +173,7 @@ private func selectViews(_ views: [HtmlView], _ documentType: DocumentType) -> [
 
         // only once nothing can throw any more: backTranslate must not be handed
         // a document whose pages were never served
-        self.document = document
+        self.document = openedDocument
 
         pageNames = views.map(\.name)
         pageURLs = views.map { base.appendingPathComponent($0.path) }

--- a/OpenDocumentReader/Document.swift
+++ b/OpenDocumentReader/Document.swift
@@ -48,8 +48,7 @@ class Document: UIDocument {
     public var webview: WKWebView?
 
     public var isOdf = false
-    /// Whether the menu should offer to edit this one - the document odrcore
-    /// holds open says it can take an edit and be written back out.
+    /// Whether the menu should offer to edit this one - see `CoreWrapper.isEditable`.
     public var isEditable = false
     private var wasPageCountAnnounced = false
 

--- a/OpenDocumentReader/Document.swift
+++ b/OpenDocumentReader/Document.swift
@@ -48,6 +48,9 @@ class Document: UIDocument {
     public var webview: WKWebView?
 
     public var isOdf = false
+    /// Whether the menu should offer to edit this one - odrcore holds it open as
+    /// a document, which is what a save applies the edits to.
+    public var isEditable = false
     private var wasPageCountAnnounced = false
 
     override func load(fromContents contents: Any, ofType typeName: String?) throws {
@@ -60,6 +63,7 @@ class Document: UIDocument {
         loadProgress.completedUnitCount = 2
 
         isOdf = false
+        isEditable = false
         result = nil
         pageURLs = nil
         notify { $0.documentUpdateContent(self) }
@@ -88,6 +92,7 @@ class Document: UIDocument {
         }
 
         isOdf = true
+        isEditable = coreWrapper.isEditable
 
         loadProgress.completedUnitCount = loadProgress.totalUnitCount
 

--- a/OpenDocumentReader/Document.swift
+++ b/OpenDocumentReader/Document.swift
@@ -48,8 +48,8 @@ class Document: UIDocument {
     public var webview: WKWebView?
 
     public var isOdf = false
-    /// Whether the menu should offer to edit this one - odrcore holds it open as
-    /// a document, which is what a save applies the edits to.
+    /// Whether the menu should offer to edit this one - the document odrcore
+    /// holds open says it can take an edit and be written back out.
     public var isEditable = false
     private var wasPageCountAnnounced = false
 

--- a/OpenDocumentReader/DocumentViewController.swift
+++ b/OpenDocumentReader/DocumentViewController.swift
@@ -430,7 +430,7 @@ class DocumentViewController: UIViewController, DocumentDelegate, BannerViewDele
     @IBAction func showMenu(_ sender: Any) {
         let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
 
-        if (document?.isOdf ?? false) && !(document?.edit ?? false) {
+        if (document?.isEditable ?? false) && !(document?.edit ?? false) {
             alert.addAction(
                 UIAlertAction(
                     title: NSLocalizedString("menu_edit", comment: ""), style: .default,

--- a/OpenDocumentReaderTests/OpenDocumentReaderTests.swift
+++ b/OpenDocumentReaderTests/OpenDocumentReaderTests.swift
@@ -82,6 +82,40 @@ class OpenDocumentReaderTests: XCTestCase {
         XCTAssertEqual(wrapper.pageNames, ["document"])
     }
 
+    /// A csv reaches odrcore at all only through the decoded file — it is a text
+    /// file that also loads as a spreadsheet, so `isDocumentFile` says no and the
+    /// guard used to reject it outright.
+    func testCsvIsTranslated() throws {
+        let wrapper = CoreWrapper()
+        let url = try copyFixture(ofType: "csv")
+
+        try wrapper.translate(
+            url.path, cache: temporaryDirectory, into: temporaryDirectory, with: nil, editable: false)
+
+        XCTAssertEqual(wrapper.pageNames, ["document"])
+    }
+
+    /// And it has no document behind it, so the menu must not offer to edit one.
+    func testCsvIsNotEditable() throws {
+        let wrapper = CoreWrapper()
+        let url = try copyFixture(ofType: "csv")
+
+        try wrapper.translate(
+            url.path, cache: temporaryDirectory, into: temporaryDirectory, with: nil, editable: true)
+
+        XCTAssertFalse(wrapper.isEditable)
+    }
+
+    /// The odt does, which is what keeps the check above from passing vacuously.
+    func testATextDocumentIsEditable() throws {
+        let wrapper = CoreWrapper()
+
+        try wrapper.translate(
+            documentURL.path, cache: temporaryDirectory, into: temporaryDirectory, with: nil, editable: true)
+
+        XCTAssertTrue(wrapper.isEditable)
+    }
+
     /// Nothing is rendered to disk up front any more, so the pages have to come
     /// back off the loopback server odrcore is serving them on.
     func testPagesAreServedOverLoopback() throws {

--- a/OpenDocumentReaderTests/OpenDocumentReaderTests.swift
+++ b/OpenDocumentReaderTests/OpenDocumentReaderTests.swift
@@ -82,9 +82,7 @@ class OpenDocumentReaderTests: XCTestCase {
         XCTAssertEqual(wrapper.pageNames, ["document"])
     }
 
-    /// A csv reaches odrcore at all only through the decoded file — it is a text
-    /// file that also loads as a spreadsheet, so `isDocumentFile` says no and the
-    /// guard used to reject it outright.
+    /// A csv reaches odrcore only through the decoded file — see `isCsv`.
     func testCsvIsTranslated() throws {
         let wrapper = CoreWrapper()
         let url = try copyFixture(ofType: "csv")

--- a/OpenDocumentReaderTests/test.csv
+++ b/OpenDocumentReaderTests/test.csv
@@ -1,0 +1,4 @@
+region,units,revenue
+North,120,"1,240.00"
+South,86,"940.50"
+East,0,"0.00"


### PR DESCRIPTION
Bumps the engine from **6.2.0 to 6.4.0** and turns on what that makes available here.

## Csv

6.4 opens a csv as a spreadsheet — dialect probed, quoted fields kept whole, a value that only *looks* numeric left as text.

It reaches us only through the decoded file. A csv is a **text** file to odrcore that also loads as a spreadsheet, so `isDocumentFile` is false and `asDocumentFile()` fails on it. `CoreWrapper` therefore lets a csv past the guard and translates the *file* rather than a document. Before this, a `.csv` failed the guard and fell through to `DocumentViewController`'s web-view fallback as plain text.

It renders under the combined view rather than a tab per sheet: a csv has exactly one sheet and odrcore names it `"csv"`, which is not a tab worth showing.

## Page margins

`config.textDocumentMargin = true` gives a document the left and right of a printed page — what it was written to look like. OpenDocument.droid has had this on by default since its redesign; this is the same switch, minus the setting, which iOS never had.

## Editability follows the document, not the render

The menu asked `isOdf`, which only ever meant "the engine rendered this". A csv has no document behind it, and a format odrcore renders but cannot write back would offer Edit and then fail at the save. It now asks whether odrcore holds a document that reported `isEditable && isSavable` — the same rule `CoreLoader.host()` follows on Android.

## What the bump brings on its own

Less than the release notes suggest, because the guard admits document files and csv only — archives and images are rejected, and PDFs go to the web view. What actually reaches a user here is the rendering of the documents the app already opened: spreadsheets in a quieter grid under a row/column ruler that stays put while scrolling, and a `.docx` that breaks onto the pages it was written for with its numbered-list markers surviving a copy.

Widening the guard to everything odrcore can translate is [discussed in review](https://github.com/opendocument-app/OpenDocument.ios/pull/141#discussion_r3744779856) and deliberately left out: for most of it the web-view fallback is better, psd/wmf/emf would render blank rather than error, and the real gate is `Info.plist`'s `CFBundleDocumentTypes` rather than this guard.

## Verification

Built and ran the suite against 6.4.0 on the simulator: **30 tests pass**, including three new ones — a csv fixture that translates to one page, reports itself uneditable, and an odt that still reports itself editable so the check cannot pass vacuously.

`Package.resolved` is pinned by hand to the `v6.4.0` tag and its commit — SwiftPM version *enumeration* is broken on this machine (it cannot resolve the unchanged Google packages either), so the pin was written rather than resolved. CI resolves it normally, which is the confirmation it is right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FAevdi68rvDBqGMTAMKMVZ