### PR TITLE
Save beside the open document instead of over it

### DIFF
--- a/OpenDocumentReader/CoreWrapper.swift
+++ b/OpenDocumentReader/CoreWrapper.swift
@@ -186,11 +186,8 @@ private func isCsv(_ file: DecodedFile) -> Bool { file.fileType == .commaSeparat
 
         try HtmlTranslator.edit(document: document, diff: diff)
 
-        // Never straight onto `outputPath`, which is the document we are editing: odrcore
-        // rewrites only the parts the edit touched and streams the rest - styles, images,
-        // the mimetype entry - out of the file it opened, and it truncates the destination
-        // before that read happens. Writing in place therefore reads back what it has just
-        // emptied and leaves an archive of blank parts where the document was.
+        // odrcore streams the parts the edit did not touch out of the file it opened, and
+        // truncates the destination first - so saving onto the open document empties it
         let output = URL(fileURLWithPath: outputPath)
 
         let staging = try stagingDirectory(for: output)
@@ -203,16 +200,11 @@ private func isCsv(_ file: DecodedFile) -> Bool { file.fileType == .commaSeparat
         try moveIntoPlace(from: temporary, to: output)
     }
 
-    /// A directory to save into before taking `output`'s place, on `output`'s own volume.
-    ///
-    /// Not `NSTemporaryDirectory()`: that lives in the app container, and ``moveIntoPlace``
-    /// swaps with `replaceItemAt`, which cannot reach across volumes - a document opened out
-    /// of iCloud Drive or another Files provider is rarely on the same one.
-    ///
-    /// The caller owns what this returns and has to delete it.
+    /// A directory on `output`'s own volume, because `replaceItemAt` cannot swap across one.
+    /// The caller has to delete it.
     private func stagingDirectory(for output: URL) throws -> URL {
-        // an existing file is what names the volume; a save target the user has only just
-        // named does not exist yet, so its directory answers for it
+        // a target the user has only just named does not exist yet, so its directory
+        // names the volume instead
         let reference =
             FileManager.default.fileExists(atPath: output.path)
             ? output : output.deletingLastPathComponent()
@@ -224,8 +216,7 @@ private func isCsv(_ file: DecodedFile) -> Bool { file.fileType == .commaSeparat
             create: true)
     }
 
-    /// Keeps `output`'s extension, so odrcore's own file type detection reads the staged copy
-    /// the same way it reads the document.
+    /// Keeps `output`'s extension, which is what odrcore detects the file type from.
     private func stagedFile(in directory: URL, for output: URL) -> URL {
         let staged = directory.appendingPathComponent("odr-save-\(UUID().uuidString)")
 
@@ -234,11 +225,8 @@ private func isCsv(_ file: DecodedFile) -> Bool { file.fileType == .commaSeparat
         return staged.appendingPathExtension(output.pathExtension)
     }
 
-    /// Replaces `output` with the file at `temporary`.
-    ///
-    /// `replaceItemAt` only where there is something to replace - it needs an existing item,
-    /// and a save target the user has just named may not exist yet.
     private func moveIntoPlace(from temporary: URL, to output: URL) throws {
+        // replaceItemAt needs something to replace, and a newly named target has nothing
         if FileManager.default.fileExists(atPath: output.path) {
             _ = try FileManager.default.replaceItemAt(output, withItemAt: temporary)
         } else {

--- a/OpenDocumentReader/CoreWrapper.swift
+++ b/OpenDocumentReader/CoreWrapper.swift
@@ -185,7 +185,58 @@ private func isCsv(_ file: DecodedFile) -> Bool { file.fileType == .commaSeparat
         }
 
         try HtmlTranslator.edit(document: document, diff: diff)
-        try document.save(to: outputPath)
+
+        // Never straight onto `outputPath`, which is the document we are editing: odrcore
+        // rewrites only the parts the edit touched and streams the rest - styles, images,
+        // the mimetype entry - out of the file it opened, and it truncates the destination
+        // before that read happens. Writing in place therefore reads back what it has just
+        // emptied and leaves an archive of blank parts where the document was.
+        let temporaryPath = temporaryNeighbour(of: outputPath)
+
+        do {
+            try document.save(to: temporaryPath)
+        } catch {
+            try? FileManager.default.removeItem(atPath: temporaryPath)
+
+            throw error
+        }
+
+        try moveIntoPlace(from: temporaryPath, to: outputPath)
+    }
+
+    /// A path to write to before taking `outputPath`'s place, keeping its extension so
+    /// odrcore's own file type detection reads it the same way.
+    private func temporaryNeighbour(of outputPath: String) -> String {
+        let output = URL(fileURLWithPath: outputPath)
+        let name = "odr-save-\(UUID().uuidString)"
+
+        var temporary = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(name)
+        if !output.pathExtension.isEmpty {
+            temporary.appendPathExtension(output.pathExtension)
+        }
+
+        return temporary.path
+    }
+
+    /// Replaces `outputPath` with the file at `temporaryPath`.
+    ///
+    /// `replaceItemAt` only where there is something to replace - it needs an existing item,
+    /// and a save target the user has just named may not exist yet.
+    private func moveIntoPlace(from temporaryPath: String, to outputPath: String) throws {
+        let temporary = URL(fileURLWithPath: temporaryPath)
+        let output = URL(fileURLWithPath: outputPath)
+
+        do {
+            if FileManager.default.fileExists(atPath: outputPath) {
+                _ = try FileManager.default.replaceItemAt(output, withItemAt: temporary)
+            } else {
+                try FileManager.default.moveItem(at: temporary, to: output)
+            }
+        } catch {
+            try? FileManager.default.removeItem(at: temporary)
+
+            throw error
+        }
     }
 
     /// Whether odrcore is serving this URL, rather than it being somewhere a

--- a/OpenDocumentReader/CoreWrapper.swift
+++ b/OpenDocumentReader/CoreWrapper.swift
@@ -191,51 +191,58 @@ private func isCsv(_ file: DecodedFile) -> Bool { file.fileType == .commaSeparat
         // the mimetype entry - out of the file it opened, and it truncates the destination
         // before that read happens. Writing in place therefore reads back what it has just
         // emptied and leaves an archive of blank parts where the document was.
-        let temporaryPath = temporaryNeighbour(of: outputPath)
-
-        do {
-            try document.save(to: temporaryPath)
-        } catch {
-            try? FileManager.default.removeItem(atPath: temporaryPath)
-
-            throw error
-        }
-
-        try moveIntoPlace(from: temporaryPath, to: outputPath)
-    }
-
-    /// A path to write to before taking `outputPath`'s place, keeping its extension so
-    /// odrcore's own file type detection reads it the same way.
-    private func temporaryNeighbour(of outputPath: String) -> String {
         let output = URL(fileURLWithPath: outputPath)
-        let name = "odr-save-\(UUID().uuidString)"
 
-        var temporary = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(name)
-        if !output.pathExtension.isEmpty {
-            temporary.appendPathExtension(output.pathExtension)
-        }
+        let staging = try stagingDirectory(for: output)
+        defer { try? FileManager.default.removeItem(at: staging) }
 
-        return temporary.path
+        let temporary = stagedFile(in: staging, for: output)
+
+        try document.save(to: temporary.path)
+
+        try moveIntoPlace(from: temporary, to: output)
     }
 
-    /// Replaces `outputPath` with the file at `temporaryPath`.
+    /// A directory to save into before taking `output`'s place, on `output`'s own volume.
+    ///
+    /// Not `NSTemporaryDirectory()`: that lives in the app container, and ``moveIntoPlace``
+    /// swaps with `replaceItemAt`, which cannot reach across volumes - a document opened out
+    /// of iCloud Drive or another Files provider is rarely on the same one.
+    ///
+    /// The caller owns what this returns and has to delete it.
+    private func stagingDirectory(for output: URL) throws -> URL {
+        // an existing file is what names the volume; a save target the user has only just
+        // named does not exist yet, so its directory answers for it
+        let reference =
+            FileManager.default.fileExists(atPath: output.path)
+            ? output : output.deletingLastPathComponent()
+
+        return try FileManager.default.url(
+            for: .itemReplacementDirectory,
+            in: .userDomainMask,
+            appropriateFor: reference,
+            create: true)
+    }
+
+    /// Keeps `output`'s extension, so odrcore's own file type detection reads the staged copy
+    /// the same way it reads the document.
+    private func stagedFile(in directory: URL, for output: URL) -> URL {
+        let staged = directory.appendingPathComponent("odr-save-\(UUID().uuidString)")
+
+        guard !output.pathExtension.isEmpty else { return staged }
+
+        return staged.appendingPathExtension(output.pathExtension)
+    }
+
+    /// Replaces `output` with the file at `temporary`.
     ///
     /// `replaceItemAt` only where there is something to replace - it needs an existing item,
     /// and a save target the user has just named may not exist yet.
-    private func moveIntoPlace(from temporaryPath: String, to outputPath: String) throws {
-        let temporary = URL(fileURLWithPath: temporaryPath)
-        let output = URL(fileURLWithPath: outputPath)
-
-        do {
-            if FileManager.default.fileExists(atPath: outputPath) {
-                _ = try FileManager.default.replaceItemAt(output, withItemAt: temporary)
-            } else {
-                try FileManager.default.moveItem(at: temporary, to: output)
-            }
-        } catch {
-            try? FileManager.default.removeItem(at: temporary)
-
-            throw error
+    private func moveIntoPlace(from temporary: URL, to output: URL) throws {
+        if FileManager.default.fileExists(atPath: output.path) {
+            _ = try FileManager.default.replaceItemAt(output, withItemAt: temporary)
+        } else {
+            try FileManager.default.moveItem(at: temporary, to: output)
         }
     }
 

--- a/OpenDocumentReaderTests/OpenDocumentReaderTests.swift
+++ b/OpenDocumentReaderTests/OpenDocumentReaderTests.swift
@@ -232,6 +232,33 @@ class OpenDocumentReaderTests: XCTestCase {
         XCTAssertTrue(FileManager.default.fileExists(atPath: editedURL.path))
     }
 
+    /// Where every real save lands: on the document odrcore still has open.
+    ///
+    /// Saving used to write straight to that path, which truncates it before the
+    /// parts the edit did not touch have been streamed out of it - so styles,
+    /// images and the mimetype entry all came back empty and the document was
+    /// gone.
+    func testBackTranslateOverTheOpenDocumentLeavesItReadable() throws {
+        let wrapper = CoreWrapper()
+
+        try wrapper.translate(
+            documentURL.path, cache: temporaryDirectory, into: temporaryDirectory, with: nil, editable: true)
+
+        let diff = """
+            {"modifiedText":{"/child:3/child:0":"Saved over itself."}}
+            """
+
+        try wrapper.backTranslate(diff, into: documentURL.path)
+
+        // the whole document has to survive, not only the part the edit rewrote
+        let reopened = CoreWrapper()
+        try reopened.translate(
+            documentURL.path, cache: temporaryDirectory, into: temporaryDirectory, with: nil, editable: true)
+
+        XCTAssertFalse(reopened.pageURLs.isEmpty)
+        XCTAssertTrue(reopened.isEditable)
+    }
+
     /// backTranslate used to dereference an empty std::optional when nothing had
     /// been translated yet.
     func testBackTranslateWithoutTranslateFails() {

--- a/OpenDocumentReaderTests/OpenDocumentReaderTests.swift
+++ b/OpenDocumentReaderTests/OpenDocumentReaderTests.swift
@@ -233,11 +233,6 @@ class OpenDocumentReaderTests: XCTestCase {
     }
 
     /// Where every real save lands: on the document odrcore still has open.
-    ///
-    /// Saving used to write straight to that path, which truncates it before the
-    /// parts the edit did not touch have been streamed out of it - so styles,
-    /// images and the mimetype entry all came back empty and the document was
-    /// gone.
     func testBackTranslateOverTheOpenDocumentLeavesItReadable() throws {
         let wrapper = CoreWrapper()
 


### PR DESCRIPTION
Editing and saving a document destroys it.

`Document.save` hands odrcore the document's own path as the save target. odrcore rewrites only the parts the edit touched and streams everything else — styles, images, the `mimetype` entry — out of the file it opened, but `util::file::create` truncates the destination before that read happens (`odf_document.cpp:74`, `zip_archive.cpp:75`, `common/file.cpp:35`). So the save reads back the file it has just emptied and writes an archive of blank parts over the user's document.

`backTranslate` now saves to a temporary neighbour and moves that into place, which is the shape OpenDocument.droid already uses — it retranslates into a cache file and copies that onto the target.

The new test translates the fixture, saves over it, and reopens it; it fails on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)