### PR TITLE
Serve images instead of embedding them

### DIFF
--- a/OpenDocumentReader/CoreWrapper.swift
+++ b/OpenDocumentReader/CoreWrapper.swift
@@ -135,10 +135,7 @@ private func isCsv(_ file: DecodedFile) -> Bool { file.fileType == .commaSeparat
         config.relativeResourcePaths = false
         // the side margins of a printed page, which is what it was written to look like
         config.textDocumentMargin = true
-        // served off the same loopback server as the pages rather than inlined, the
-        // way OpenDocument.droid has always had it: embedding turns every picture in
-        // a document into base64 in the markup, so one full of photographs arrives as
-        // a single page the web view has to hold whole
+        // served with the pages rather than inlined as base64, as in OpenDocument.droid
         config.embedImages = false
 
         let documentType: DocumentType

--- a/OpenDocumentReader/CoreWrapper.swift
+++ b/OpenDocumentReader/CoreWrapper.swift
@@ -135,6 +135,11 @@ private func isCsv(_ file: DecodedFile) -> Bool { file.fileType == .commaSeparat
         config.relativeResourcePaths = false
         // the side margins of a printed page, which is what it was written to look like
         config.textDocumentMargin = true
+        // served off the same loopback server as the pages rather than inlined, the
+        // way OpenDocument.droid has always had it: embedding turns every picture in
+        // a document into base64 in the markup, so one full of photographs arrives as
+        // a single page the web view has to hold whole
+        config.embedImages = false
 
         let documentType: DocumentType
         let openedDocument: OdrCoreObjC.Document?


### PR DESCRIPTION
`HtmlConfig.embedImages` defaults to `true` in odrcore, and nothing here turned it off — so every picture in a document was inlined as a base64 data URI and the web view had to hold the whole page at once.

OpenDocument.droid sets `embedImages = false` (`CoreLoader.kt:177`) and has done since it moved to the loopback server. The pages are served the same way here, so the images can come off the same server.

`textDocumentMargin` stays `true`, which is what Android's `PaginationSetting` also defaults to — the two now agree on all four of odrcore's html options.

🤖 Generated with [Claude Code](https://claude.com/claude-code)