### PR TITLE
Rotate the house ad once per presentation

### DIFF
--- a/OpenDocumentReader/HouseAdView.swift
+++ b/OpenDocumentReader/HouseAdView.swift
@@ -71,9 +71,8 @@ final class HouseAdView: UIView {
     private let textStack = UIStackView()
     private let stack = UIStackView()
 
-    /// What the labels are laid out against until ``rotate()`` picks the one that is actually
-    /// shown. Not a rotation itself: taking one here spent a turn on every view that was built,
-    /// including the ones in the paid app that never show a promotion at all.
+    /// Placeholder until ``rotate()`` picks the one shown - taking a rotation here would spend
+    /// one per view built, including in the paid app.
     private var creative = HouseAdView.creatives[0]
 
     /// Called when the promotion is tapped, so the controller can present the store.

--- a/OpenDocumentReader/HouseAdView.swift
+++ b/OpenDocumentReader/HouseAdView.swift
@@ -71,7 +71,10 @@ final class HouseAdView: UIView {
     private let textStack = UIStackView()
     private let stack = UIStackView()
 
-    private var creative = HouseAdView.nextCreative()
+    /// What the labels are laid out against until ``rotate()`` picks the one that is actually
+    /// shown. Not a rotation itself: taking one here spent a turn on every view that was built,
+    /// including the ones in the paid app that never show a promotion at all.
+    private var creative = HouseAdView.creatives[0]
 
     /// Called when the promotion is tapped, so the controller can present the store.
     var onTap: (() -> Void)?


### PR DESCRIPTION
`HouseAdView` took a rotation in its property initializer *and* another in `rotate()`, so every presentation spent two — against the doc comment right above it, which says once. The paid app spent one per document opened without ever showing a promotion, since the view is built either way.

The initial value is now just what the labels are laid out against; `rotate()`, called from `showHouseAd()` before the view is unhidden, is the only thing that advances the stored index.