### PR TITLE
Resize the banner on rotation

### DIFF
--- a/Ads/AdSlot.swift
+++ b/Ads/AdSlot.swift
@@ -15,6 +15,10 @@ final class AdSlot: NSObject, BannerViewDelegate {
     private let bannerView = BannerView()
     private weak var host: UIViewController?
 
+    /// Whether an ad has been asked for, which is what ``resize()`` needs to know: consent
+    /// settling is the only thing that starts one.
+    private var hasRequestedAd = false
+
     /// Puts the banner in `slot` and gathers consent. Once per controller: the form is modal, so a
     /// second call on reappearance would bring it back.
     func start(in slot: UIView, from viewController: UIViewController) {
@@ -62,8 +66,24 @@ final class AdSlot: NSObject, BannerViewDelegate {
         ])
     }
 
+    /// Sizes the banner for the slot it has now and asks for one that fits.
+    ///
+    /// An anchored adaptive banner is sized for the width and orientation it was requested at, so
+    /// a rotation leaves the one on screen the wrong shape for its slot. OpenDocument.droid
+    /// rebuilds it from onConfigurationChanged for the same reason.
+    ///
+    /// Only once something has been requested: before that, consent has not settled and the slot
+    /// belongs to the house ad, which sizes itself.
+    func resize() {
+        guard hasRequestedAd else { return }
+
+        load()
+    }
+
     private func load() {
         guard let view = host?.view else { return }
+
+        hasRequestedAd = true
 
         let viewWidth = view.frame.inset(by: view.safeAreaInsets).size.width
 

--- a/Ads/AdSlot.swift
+++ b/Ads/AdSlot.swift
@@ -15,9 +15,9 @@ final class AdSlot: NSObject, BannerViewDelegate {
     private let bannerView = BannerView()
     private weak var host: UIViewController?
 
-    /// Whether an ad has been asked for, which is what ``resize()`` needs to know: consent
-    /// settling is the only thing that starts one.
-    private var hasRequestedAd = false
+    /// The width the banner was last asked for at. Nil until consent settles and ``load()``
+    /// makes the first request.
+    private var requestedWidth: CGFloat?
 
     /// Puts the banner in `slot` and gathers consent. Once per controller: the form is modal, so a
     /// second call on reappearance would bring it back.
@@ -66,16 +66,10 @@ final class AdSlot: NSObject, BannerViewDelegate {
         ])
     }
 
-    /// Sizes the banner for the slot it has now and asks for one that fits.
-    ///
-    /// An anchored adaptive banner is sized for the width and orientation it was requested at, so
-    /// a rotation leaves the one on screen the wrong shape for its slot. OpenDocument.droid
-    /// rebuilds it from onConfigurationChanged for the same reason.
-    ///
-    /// Only once something has been requested: before that, consent has not settled and the slot
-    /// belongs to the house ad, which sizes itself.
+    /// Asks for a banner sized to the slot as it is now: an anchored adaptive banner keeps the
+    /// shape it was requested at. Never the first request - that one waits for consent.
     func resize() {
-        guard hasRequestedAd else { return }
+        guard requestedWidth != nil else { return }
 
         load()
     }
@@ -83,11 +77,13 @@ final class AdSlot: NSObject, BannerViewDelegate {
     private func load() {
         guard let view = host?.view else { return }
 
-        hasRequestedAd = true
+        let width = view.frame.inset(by: view.safeAreaInsets).size.width
 
-        let viewWidth = view.frame.inset(by: view.safeAreaInsets).size.width
+        // a transition that left the width alone needs no new ad
+        guard width > 0, width != requestedWidth else { return }
+        requestedWidth = width
 
-        bannerView.adSize = currentOrientationAnchoredAdaptiveBanner(width: viewWidth)
+        bannerView.adSize = currentOrientationAnchoredAdaptiveBanner(width: width)
         bannerView.load(Request())
     }
 

--- a/NoAds/AdSlot.swift
+++ b/NoAds/AdSlot.swift
@@ -8,4 +8,6 @@ final class AdSlot {
     var onAd: (() -> Void)?
 
     func start(in slot: UIView, from viewController: UIViewController) {}
+
+    func resize() {}
 }

--- a/OpenDocumentReader/DocumentViewController.swift
+++ b/OpenDocumentReader/DocumentViewController.swift
@@ -175,6 +175,21 @@ class DocumentViewController: UIViewController, DocumentDelegate, UISearchBarDel
         adSlot.start(in: bannerSlot, from: self)
     }
 
+    /// The banner's size follows the orientation; the consent behind it does not.
+    override func viewWillTransition(
+        to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator
+    ) {
+        super.viewWillTransition(to: size, with: coordinator)
+
+        guard Features.withAds else { return }
+
+        // afterwards, not alongside: the slot's own width is what the new banner is sized
+        // against, and it only has it once the rotation has settled
+        coordinator.animate(alongsideTransition: nil) { [weak self] _ in
+            self?.adSlot.resize()
+        }
+    }
+
     func setVCconstraints() {
         searchBar.translatesAutoresizingMaskIntoConstraints = false
         bannerSlot.translatesAutoresizingMaskIntoConstraints = false

--- a/OpenDocumentReader/DocumentViewController.swift
+++ b/OpenDocumentReader/DocumentViewController.swift
@@ -183,8 +183,7 @@ class DocumentViewController: UIViewController, DocumentDelegate, UISearchBarDel
 
         guard Features.withAds else { return }
 
-        // afterwards, not alongside: the slot's own width is what the new banner is sized
-        // against, and it only has it once the rotation has settled
+        // afterwards, not alongside: the slot only has its new width once the rotation settled
         coordinator.animate(alongsideTransition: nil) { [weak self] _ in
             self?.adSlot.resize()
         }


### PR DESCRIPTION
An anchored adaptive banner is sized for the width and orientation it was requested at. `AdSlot` sized one once, when consent settled, and never again — so rotating the device left a banner shaped for the old orientation sitting in a slot that had changed width.

OpenDocument.droid rebuilds its banner from `onConfigurationChanged` for exactly this reason (`AdManager.refreshAds`); this is the same thing on the iOS side, from `viewWillTransition`.

`resize()` does nothing until an ad has actually been requested: before consent settles the slot belongs to the house ad, which sizes itself from its own `layoutSubviews`.

This is the last of the ad-behaviour differences I held back while #142 was in flight.