### PR TITLE
Take odrcore 6.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,15 +40,8 @@ once the version tag exists.
   quieter grid, under a row and column ruler that stays put while scrolling, and
   a .docx breaks onto the pages it was written for, its numbered lists carrying
   their markers into a copy.
-- An .xml file opens as a foldable, highlighted source view, in the encoding its
-  declaration names, instead of as one very long line.
-- An .svg is recognised by what is in it rather than by what it is called, so a
-  file that is not one no longer opens as an image that cannot be shown.
-- Plain text reads in a quieter gutter: the line numbers line up with their
-  lines, stay out of a copy of the page, and the line under the pointer is
-  marked.
-- No document opens inset by a thin border any more. Every page now states the
-  margin and background it wants instead of inheriting the web view's.
+- An .xml file opens properly laid out instead of as one long line.
+- Smaller fixes to plain text and to the margin documents open with.
 - Edit is offered only for a document the engine holds open for editing, rather
   than for anything it managed to render.
 - Pro no longer contains the Google ad and consent SDKs. It is built as its own

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,10 +36,19 @@ once the version tag exists.
   leaves limited ads, which carry none, rather than no ads at all.
 - Documents keep the side margins of a printed page, which is what they were
   written to look like.
-- The engine is odrcore 6.4.0, up from 6.2.0. Spreadsheets are drawn in a
+- The engine is odrcore 6.5.0, up from 6.2.0. Spreadsheets are drawn in a
   quieter grid, under a row and column ruler that stays put while scrolling, and
   a .docx breaks onto the pages it was written for, its numbered lists carrying
   their markers into a copy.
+- An .xml file opens as a foldable, highlighted source view, in the encoding its
+  declaration names, instead of as one very long line.
+- An .svg is recognised by what is in it rather than by what it is called, so a
+  file that is not one no longer opens as an image that cannot be shown.
+- Plain text reads in a quieter gutter: the line numbers line up with their
+  lines, stay out of a copy of the page, and the line under the pointer is
+  marked.
+- No document opens inset by a thin border any more. Every page now states the
+  margin and background it wants instead of inheriting the web view's.
 - Edit is offered only for a document the engine holds open for editing, rather
   than for anything it managed to render.
 - Pro no longer contains the Google ad and consent SDKs. It is built as its own

--- a/OpenDocumentReader.xcodeproj/project.pbxproj
+++ b/OpenDocumentReader.xcodeproj/project.pbxproj
@@ -738,7 +738,7 @@
 			repositoryURL = "https://github.com/opendocument-app/OpenDocument.core.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 6.4.0;
+				minimumVersion = 6.5.0;
 			};
 		};
 		AD584FCD41577C8CDEE974AA /* XCRemoteSwiftPackageReference "swift-package-manager-google-mobile-ads" */ = {


### PR DESCRIPTION
Bumps the SwiftPM requirement from 6.4.0 to 6.5.0 and folds what the release brings into the open `Unreleased` section — that section already carried a 6.4.0 line, so it moves rather than gaining a second engine bullet.

xml gets a source view, an svg is recognised by its bytes rather than its name, plain text gets a gutter that stays out of a copy, and a page states its own body margin instead of inheriting the web view's eight-pixel one.

Nothing else in the app changes. `EXTENSION_WHITELIST` in `DocumentViewController` still lists `svg` and `xml`, but it is only reached after odrcore fails, and 6.5.0 renders both — so it stops being the path they take without being touched.

**Blocked on the release.** odrcore 6.5.0 is not cut yet; this cannot build until it is. `Package.resolved` still pins 6.4.0 because the tag has no revision yet — Xcode re-resolves it on the first build after the release, and that resolve should be committed here before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)