### PR TITLE
Take odrcore 6.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,26 +44,23 @@ once the version tag exists.
   than for anything it managed to render.
 - Pro no longer contains the Google ad and consent SDKs. It is built as its own
   target now and links neither, taking its executable from 4.4 MB to 0.5 MB.
-- The engine is odrcore 6.6.0, up from 6.2.0. Documents come out closer to what
-  they look like in the program that wrote them:
-  - Word documents break onto the pages they were written for, and numbered
-    lists keep their markers when you copy text out of one.
-  - Spreadsheets are drawn in a quieter grid, under a row and column ruler that
-    stays put while scrolling, and their cells are set in the font the file
-    names.
-  - Slides show text that was there all along but drawn in no font at all.
-  - Pictures sit where the document puts them: centred where the file centres
-    them, inside their frame, and in the box a letter pins them to rather than
-    adrift in the running text.
-  - Documents built on a template keep the margins that template leaves free,
-    such as the room a letterhead needs.
-  - PDFs are truer to the file. Text sits where it belongs instead of a few
-    points low, colours match what a PDF viewer shows, a page is cropped the
-    way a viewer crops it, and pages that used to come up blank — commented
-    content, JPEG 2000 images — now draw.
-  - XML files open properly laid out instead of as one long line.
-  - Documents whose styles are built on one another many levels deep open
-    instead of taking the app down with them.
+- The engine is odrcore 6.6.0, up from 6.2.0. Everything below is what it
+  renders differently.
+- Word documents break onto the pages they were written for, and numbered lists
+  keep their markers when you copy text out of one.
+- Spreadsheets are drawn in a quieter grid, under a row and column ruler that
+  stays put while scrolling, and their cells are set in the font the file names.
+- Slides show text that was there all along but drawn in no font at all.
+- Pictures sit where the document puts them: centred where the file centres
+  them, inside their frame, and in the box a letter pins them to rather than
+  adrift in the running text.
+- Documents built on a template keep the margins that template leaves free, such
+  as the room a letterhead needs.
+- PDFs are truer to the file. Text sits where it belongs instead of a few points
+  low, colours match what a PDF viewer shows, a page is cropped the way a viewer
+  crops it, and pages that used to come up blank — commented content, JPEG 2000
+  images — now draw.
+- XML files open properly laid out instead of as one long line.
 
 ### Fixed
 
@@ -71,6 +68,8 @@ once the version tag exists.
   beside the original and moved into place once it is whole; it used to be
   written over the document it was still reading from, which left an unopenable
   file behind.
+- A document whose styles are built on one another many levels deep opens
+  instead of taking the app down with it.
 - The ad in the Lite app is resized when the device is rotated, instead of
   keeping the shape it was requested at.
 - The ad slot in the Lite app no longer shows a brown bar. It was a placeholder

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,10 +56,6 @@ once the version tag exists.
   adrift in the running text.
 - Documents built on a template keep the margins that template leaves free, such
   as the room a letterhead needs.
-- PDFs are truer to the file. Text sits where it belongs instead of a few points
-  low, colours match what a PDF viewer shows, a page is cropped the way a viewer
-  crops it, and pages that used to come up blank — commented content, JPEG 2000
-  images — now draw.
 - XML files open properly laid out instead of as one long line.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,18 +38,32 @@ once the version tag exists.
   leaves limited ads, which carry none, rather than no ads at all.
 - Documents keep the side margins of a printed page, which is what they were
   written to look like.
-- The engine is odrcore 6.5.0, up from 6.2.0. Spreadsheets are drawn in a
-  quieter grid, under a row and column ruler that stays put while scrolling, and
-  a .docx breaks onto the pages it was written for, its numbered lists carrying
-  their markers into a copy.
-- An .xml file opens properly laid out instead of as one long line.
 - Documents with pictures open faster and hold less memory: the images are
   fetched as the page needs them instead of being built into it.
-- Smaller fixes to plain text and to the margin documents open with.
 - Edit is offered only for a document the engine holds open for editing, rather
   than for anything it managed to render.
 - Pro no longer contains the Google ad and consent SDKs. It is built as its own
   target now and links neither, taking its executable from 4.4 MB to 0.5 MB.
+- The engine is odrcore 6.6.0, up from 6.2.0. Documents come out closer to what
+  they look like in the program that wrote them:
+  - Word documents break onto the pages they were written for, and numbered
+    lists keep their markers when you copy text out of one.
+  - Spreadsheets are drawn in a quieter grid, under a row and column ruler that
+    stays put while scrolling, and their cells are set in the font the file
+    names.
+  - Slides show text that was there all along but drawn in no font at all.
+  - Pictures sit where the document puts them: centred where the file centres
+    them, inside their frame, and in the box a letter pins them to rather than
+    adrift in the running text.
+  - Documents built on a template keep the margins that template leaves free,
+    such as the room a letterhead needs.
+  - PDFs are truer to the file. Text sits where it belongs instead of a few
+    points low, colours match what a PDF viewer shows, a page is cropped the
+    way a viewer crops it, and pages that used to come up blank — commented
+    content, JPEG 2000 images — now draw.
+  - XML files open properly laid out instead of as one long line.
+  - Documents whose styles are built on one another many levels deep open
+    instead of taking the app down with them.
 
 ### Fixed
 

--- a/OpenDocumentReader.xcodeproj/project.pbxproj
+++ b/OpenDocumentReader.xcodeproj/project.pbxproj
@@ -738,7 +738,7 @@
 			repositoryURL = "https://github.com/opendocument-app/OpenDocument.core.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 6.5.0;
+				minimumVersion = 6.6.0;
 			};
 		};
 		AD584FCD41577C8CDEE974AA /* XCRemoteSwiftPackageReference "swift-package-manager-google-mobile-ads" */ = {

--- a/OpenDocumentReader.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OpenDocumentReader.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "fb74b10a80d07407e1cef4ff366c543de15a310f0a4ae23e7fdda72de7a12f43",
+  "originHash" : "8a16f3ab10f63ca384f7610f0fa000e9080c756f1737be27cd7537a2916c52e0",
   "pins" : [
     {
       "identity" : "opendocument.core",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/opendocument-app/OpenDocument.core.git",
       "state" : {
-        "revision" : "a50cda610027f1c5638caf357e348aeb2f4c524c",
-        "version" : "6.4.0"
+        "revision" : "c7b9c37b8436f3823fcc4213522218b6bc15c6b6",
+        "version" : "6.6.0"
       }
     },
     {

--- a/fastlane/metadata/en-US/changelogs/1.38.txt
+++ b/fastlane/metadata/en-US/changelogs/1.38.txt
@@ -3,6 +3,8 @@
 - Word documents break onto the pages they were written for, and numbered lists keep their markers when you copy text out of one
 - Spreadsheets are drawn in a quieter grid, under a row and column ruler that stays put while scrolling
 - Documents keep the side margins of a printed page
+- Pictures sit where the document puts them, and slides show text that used to be invisible
+- PDFs are truer to the file: text and colours are placed as a PDF viewer places them, and pages that used to come up blank now draw
 - Documents with pictures open faster and use less memory
 - XML files open properly laid out instead of as one long line
 - The free app asks for advertising consent where that is required, and a new Privacy entry reopens the choice at any time

--- a/fastlane/metadata/en-US/changelogs/1.38.txt
+++ b/fastlane/metadata/en-US/changelogs/1.38.txt
@@ -4,7 +4,6 @@
 - Spreadsheets are drawn in a quieter grid, under a row and column ruler that stays put while scrolling
 - Documents keep the side margins of a printed page
 - Pictures sit where the document puts them, and slides show text that used to be invisible
-- PDFs are truer to the file: text and colours are placed as a PDF viewer places them, and pages that used to come up blank now draw
 - Documents with pictures open faster and use less memory
 - XML files open properly laid out instead of as one long line
 - The free app asks for advertising consent where that is required, and a new Privacy entry reopens the choice at any time


### PR DESCRIPTION
Pictures land where the document puts them, slides show text that was drawn in
no font at all, letters are laid out on the master page they name, cells are
set in the font the sheet names, and a deeply chained style no longer takes the
app down.

6.6.0 also carries a lot of pdf work — text placement, cmyk, the crop box,
comments, jpeg 2000. None of it ships here: `CoreWrapper.translate` rejects
`portableDocumentFormat` before decoding and the view controller hands the file
to WKWebView, which renders pdfs natively. So it is not in the notes.

`Package.resolved` moves to 6.6.0 with it. It had been left at 6.4.0 because
6.5.0's tag did not exist yet; it does now, so the pin catches up in the same
step.

## Changelog

1.38 carried four bullets that all said the engine changed — the engine bump,
xml, "smaller fixes", and the margins a second time. They are flat bullets now,
one per thing a reader sees, with the version line saying what the ones below
it come from, and 6.6.0's changes fold in there rather than adding a fifth
"the engine changed" bullet. The crash on a deeply chained style sits under
Fixed. The store copy gains the line worth a line there: pictures and slides.

The section is already cut to `1.38` and not yet released, so this goes under
the cut heading, per the rule at the top of the changelog.

## Test plan

- [x] `bundle exec fastlane tests` — 32 tests, 0 failures, against 6.6.0
- [ ] CI builds both schemes for device

Note for whoever resolves next locally: `column.ui = always` in a global git
config makes `git tag` print in columns, which SwiftPM reads as a package with
no versions — resolution then fails with "no versions match". Working around it
per command: `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=column.ui GIT_CONFIG_VALUE_0=never`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NN8f956dRTimWZezhfGXQf