### PR TITLE
Cut 1.39, and take the engine entries off 1.38

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,28 @@ open: **a second build under the same version goes under the already cut
 heading, not back under `Unreleased`.** Date the heading and add its compare link
 once the version tag exists.
 
-## [1.38]
+## [1.39]
+
+### Changed
+
+- The engine is odrcore 6.6.0, up from 6.5.0. Everything below is what it
+  renders differently.
+- Slides show text that was there all along but drawn in no font at all.
+- Pictures sit where the document puts them: centred where the file centres
+  them, inside their frame, and in the box a letter pins them to rather than
+  adrift in the running text.
+- Documents built on a template keep the margins that template leaves free, such
+  as the room a letterhead needs.
+- Spreadsheet cells are set in the font the file names, rather than the sheet's
+  own throughout.
+- Large documents take less memory to open.
+
+### Fixed
+
+- A document whose styles are built on one another many levels deep opens
+  instead of taking the app down with it.
+
+## [1.38] - 2026-08-10
 
 ### Added
 
@@ -44,18 +65,12 @@ once the version tag exists.
   than for anything it managed to render.
 - Pro no longer contains the Google ad and consent SDKs. It is built as its own
   target now and links neither, taking its executable from 4.4 MB to 0.5 MB.
-- The engine is odrcore 6.6.0, up from 6.2.0. Everything below is what it
+- The engine is odrcore 6.5.0, up from 6.2.0. Everything below is what it
   renders differently.
 - Word documents break onto the pages they were written for, and numbered lists
   keep their markers when you copy text out of one.
 - Spreadsheets are drawn in a quieter grid, under a row and column ruler that
-  stays put while scrolling, and their cells are set in the font the file names.
-- Slides show text that was there all along but drawn in no font at all.
-- Pictures sit where the document puts them: centred where the file centres
-  them, inside their frame, and in the box a letter pins them to rather than
-  adrift in the running text.
-- Documents built on a template keep the margins that template leaves free, such
-  as the room a letterhead needs.
+  stays put while scrolling.
 - XML files open properly laid out instead of as one long line.
 
 ### Fixed
@@ -64,8 +79,6 @@ once the version tag exists.
   beside the original and moved into place once it is whole; it used to be
   written over the document it was still reading from, which left an unopenable
   file behind.
-- A document whose styles are built on one another many levels deep opens
-  instead of taking the app down with it.
 - The ad in the Lite app is resized when the device is rotated, instead of
   keeping the shape it was requested at.
 - The ad slot in the Lite app no longer shows a brown bar. It was a placeholder
@@ -134,7 +147,8 @@ submitted.
 - An incorrect password is now reported as such instead of a generic failure.
 - Page handling and decryption fixes when opening protected documents.
 
-[Unreleased]: https://github.com/opendocument-app/OpenDocument.ios/compare/1.37...HEAD
+[Unreleased]: https://github.com/opendocument-app/OpenDocument.ios/compare/1.38...HEAD
+[1.38]: https://github.com/opendocument-app/OpenDocument.ios/compare/1.37...1.38
 [1.37]: https://github.com/opendocument-app/OpenDocument.ios/compare/1.36...1.37
 [1.36]: https://github.com/opendocument-app/OpenDocument.ios/compare/1.35...1.36
 [1.35]: https://github.com/opendocument-app/OpenDocument.ios/compare/1.34...1.35

--- a/fastlane/metadata/en-US/changelogs/1.38.txt
+++ b/fastlane/metadata/en-US/changelogs/1.38.txt
@@ -3,7 +3,6 @@
 - Word documents break onto the pages they were written for, and numbered lists keep their markers when you copy text out of one
 - Spreadsheets are drawn in a quieter grid, under a row and column ruler that stays put while scrolling
 - Documents keep the side margins of a printed page
-- Pictures sit where the document puts them, and slides show text that used to be invisible
 - Documents with pictures open faster and use less memory
 - XML files open properly laid out instead of as one long line
 - The free app asks for advertising consent where that is required, and a new Privacy entry reopens the choice at any time

--- a/fastlane/metadata/en-US/changelogs/1.39.txt
+++ b/fastlane/metadata/en-US/changelogs/1.39.txt
@@ -1,0 +1,6 @@
+- Slides show text that used to be invisible
+- Pictures sit where the document puts them: centred where the file centres them, and inside their frame instead of adrift in the text
+- Documents built on a template keep the margins it leaves free, such as the room a letterhead needs
+- Spreadsheet cells use the font the file names for them
+- Large documents take less memory to open
+- A document whose styles are built on one another many levels deep opens instead of closing the app


### PR DESCRIPTION
1.38 is out — the tag names `ca8fab7`, the github release went up on 10 August,
and `build/1.38/46` is what was uploaded. #152 put odrcore 6.6.0's entries under
that heading, on the reading that 1.38 was still open, and added a line to
`changelogs/1.38.txt`, which is a released version's store copy. Both are
reverted here and the entries stand as their own version.

Since 1.38 shipped 6.5.0, the comparison reads 6.5.0 → 6.6.0 rather than
6.2.0 → 6.6.0.

## What is in 1.39

Everything odrcore 6.6.0 renders differently that this app can show: slide text
that was drawn in no font, picture placement, the margins a template leaves
free, cell fonts, less memory on a large document, and the crash on a style
chain many levels deep.

6.6.0's pdf work is not in it — `CoreWrapper.translate` rejects
`portableDocumentFormat` and WKWebView renders pdfs, so none of it reaches a
reader here.

## Housekeeping

1.38's heading is dated and given its compare link, which the file says to do
once the version tag exists — it does now. 1.39 gets neither until its own tag
is written, matching how 1.38 was cut.

Store copy for 1.39 is written at `fastlane/metadata/en-US/changelogs/1.39.txt`.

## After this merges

`gh workflow run release.yml -f version=1.39` on `main`, which is the next step
I have been asked to take.

🤖 Generated with [Claude Code](https://claude.com/claude-code)