### PR TITLE
Prefix release tags with a v

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -237,7 +237,7 @@ jobs:
           build_number=$(cat build-number.txt)
           [ -n "$build_number" ] || { echo "::error::build-number.txt is empty"; exit 1; }
 
-          tag="build/$version/$build_number"
+          tag="build/v$version/$build_number"
 
           # a re-run behind a repaired upload is expected, so an existing tag is
           # only wrong when it names a different commit
@@ -269,16 +269,19 @@ jobs:
           set -euo pipefail
           .github/scripts/changelog-section.py --version "$version" > "${RUNNER_TEMP}/notes.md"
 
-          if gh release view "$version" > /dev/null 2>&1; then
-            gh release edit "$version" --target "$GITHUB_SHA" --notes-file "${RUNNER_TEMP}/notes.md"
+          # the version input is bare, the tag it publishes is prefixed
+          tag="v$version"
+
+          if gh release view "$tag" > /dev/null 2>&1; then
+            gh release edit "$tag" --target "$GITHUB_SHA" --notes-file "${RUNNER_TEMP}/notes.md"
           else
             # --generate-notes appends the pull requests below the changelog section
-            gh release create "$version" \
+            gh release create "$tag" \
               --draft \
               --target "$GITHUB_SHA" \
-              --title "$version" \
+              --title "$tag" \
               --notes-file "${RUNNER_TEMP}/notes.md" \
               --generate-notes
           fi
 
-          echo "drafted \`$version\`. publishing it writes the tag - do that once it is live." >> "$GITHUB_STEP_SUMMARY"
+          echo "drafted \`$tag\`. publishing it writes the tag - do that once it is live." >> "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,8 +147,8 @@ submitted.
 - An incorrect password is now reported as such instead of a generic failure.
 - Page handling and decryption fixes when opening protected documents.
 
-[Unreleased]: https://github.com/opendocument-app/OpenDocument.ios/compare/1.38...HEAD
-[1.38]: https://github.com/opendocument-app/OpenDocument.ios/compare/1.37...1.38
-[1.37]: https://github.com/opendocument-app/OpenDocument.ios/compare/1.36...1.37
-[1.36]: https://github.com/opendocument-app/OpenDocument.ios/compare/1.35...1.36
-[1.35]: https://github.com/opendocument-app/OpenDocument.ios/compare/1.34...1.35
+[Unreleased]: https://github.com/opendocument-app/OpenDocument.ios/compare/v1.38...HEAD
+[1.38]: https://github.com/opendocument-app/OpenDocument.ios/compare/v1.37...v1.38
+[1.37]: https://github.com/opendocument-app/OpenDocument.ios/compare/v1.36...v1.37
+[1.36]: https://github.com/opendocument-app/OpenDocument.ios/compare/v1.35...v1.36
+[1.35]: https://github.com/opendocument-app/OpenDocument.ios/compare/v1.34...v1.35

--- a/README.md
+++ b/README.md
@@ -198,13 +198,16 @@ one, and `resolveBuildNumber` prints the number both apps would get.
 
 Nothing is triggered by a tag, and no tag is pushed before a build: a version
 often takes more than one build to get through review, so a tag pushed up front
-names a commit that may never ship. That is what happened to `1.37`. Tags are
+names a commit that may never ship. That is what happened to `v1.37`. Tags are
 written afterwards instead, in two kinds:
 
 | tag | who writes it | what it means |
 | --- | --- | --- |
-| `build/<version>/<build>` | the workflow, once both apps are up | this commit was uploaded as that build |
-| `<version>` | publishing the drafted release | this is what shipped |
+| `build/v<version>/<build>` | the workflow, once both apps are up | this commit was uploaded as that build |
+| `v<version>` | publishing the drafted release | this is what shipped |
+
+Both are prefixed with a `v`; the `version` input is not (`-f version=1.39`
+writes `v1.39`).
 
 One build tag, not one per app, since both share a build number. It is never
 moved: a rebuild gets the next number, so a version that takes three builds to
@@ -212,12 +215,12 @@ clear review leaves three build tags. A half uploaded release gets none, and
 neither does a lane run locally.
 
 **The version tag is written neither by hand nor by the workflow.** `record` drafts
-a GitHub release named `<version>` - the changelog section with the generated list
+a GitHub release named `v<version>` - the changelog section with the generated list
 of pull requests below it - pointing at the built commit. A draft creates no tag;
 publishing it does, at exactly that commit:
 
 ```sh
-gh release edit 1.38 --draft=false
+gh release edit v1.38 --draft=false
 ```
 
 That step stays human because App Store Connect is the only thing that knows a


### PR DESCRIPTION
The tags and GitHub releases have been renamed on the remote already: `1.38` is
now `v1.38`, and the build tags moved with them, `build/1.38/46` to
`build/v1.38/46`. All 43 tags name the same commits they did, and each release
was repointed to its new tag before the old one was deleted, so bodies, dates,
the Latest marker on 1.38 and the draft on 1.39 all survived. Release titles
moved too, since the titles were the tag names.

This pull request is the tree catching up, so the next release run does not
write an unprefixed tag beside them.

## What changes

`record` tags `build/v$version/$build_number` and drafts the release as
`v$version`. The `version` input stays bare — it is also `MARKETING_VERSION` and
what `changelog-section.py` looks up — so `gh workflow run release.yml -f
version=1.40` publishes `v1.40`.

The compare links at the foot of `CHANGELOG.md` point at the renamed tags, which
they had to: every one of them was a 404 the moment the old tags went. Their
labels stay bare, matching the `## [1.38]` headings they resolve, and so do the
headings themselves — a changelog section is a version, not a tag.

The README's tag table and the `gh release edit v1.38 --draft=false` example say
what is written now.

## Worth knowing

Old release urls do not survive the rename: `/releases/tag/1.38` is a 404 and
the release lives at `/releases/tag/v1.38`. Nothing in this repository linked
one, but anything outside it did not move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)