### PR TITLE
Put the document tool bar back under the status bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ open: **a second build under the same version goes under the already cut
 heading, not back under `Unreleased`.** Date the heading and add its compare link
 once the version tag exists.
 
+## [Unreleased]
+
+### Fixed
+
+- The buttons above an open document no longer sit on the status bar, and the
+  empty band below them is gone.
+
 ## [1.39]
 
 ### Changed
@@ -147,7 +154,8 @@ submitted.
 - An incorrect password is now reported as such instead of a generic failure.
 - Page handling and decryption fixes when opening protected documents.
 
-[Unreleased]: https://github.com/opendocument-app/OpenDocument.ios/compare/v1.38...HEAD
+[Unreleased]: https://github.com/opendocument-app/OpenDocument.ios/compare/v1.39...HEAD
+[1.39]: https://github.com/opendocument-app/OpenDocument.ios/compare/v1.38...v1.39
 [1.38]: https://github.com/opendocument-app/OpenDocument.ios/compare/v1.37...v1.38
 [1.37]: https://github.com/opendocument-app/OpenDocument.ios/compare/v1.36...v1.37
 [1.36]: https://github.com/opendocument-app/OpenDocument.ios/compare/v1.35...v1.36

--- a/OpenDocumentReader/DocumentViewController.swift
+++ b/OpenDocumentReader/DocumentViewController.swift
@@ -217,6 +217,9 @@ class DocumentViewController: UIViewController, DocumentDelegate, UISearchBarDel
         // no height here: that is bannerSlotHeight from the storyboard, which
         // hideBannerSlot zeroes, and a second one would fight it
 
+        // below the banner, which is why the tab bar is not in the tool bar's
+        // stack: an arranged subview is placed by the stack, and these would be
+        // a second answer to the same question
         pageTabBar.topAnchor.constraint(equalTo: bannerSlot.bottomAnchor).isActive = true
         pageTabBar.leadingAnchor.constraint(equalTo: view.leadingAnchor).isActive = true
         pageTabBar.trailingAnchor.constraint(equalTo: view.trailingAnchor).isActive = true

--- a/OpenDocumentReader/DocumentViewController.swift
+++ b/OpenDocumentReader/DocumentViewController.swift
@@ -189,6 +189,17 @@ class DocumentViewController: UIViewController, DocumentDelegate, UISearchBarDel
         }
     }
 
+    /// From iOS 26 the bar's buttons are glass capsules filling its whole
+    /// height, which whatever is pinned to its bottom edge would cut off. Older
+    /// bars have a background of their own and want no such gap.
+    private static var toolBarBottomMargin: CGFloat {
+        if #available(iOS 26.0, *) {
+            return 8
+        }
+
+        return 0
+    }
+
     func setVCconstraints() {
         searchBar.translatesAutoresizingMaskIntoConstraints = false
         bannerSlot.translatesAutoresizingMaskIntoConstraints = false
@@ -197,7 +208,8 @@ class DocumentViewController: UIViewController, DocumentDelegate, UISearchBarDel
 
         searchBar.leadingAnchor.constraint(equalTo: view.leadingAnchor).isActive = true
         searchBar.trailingAnchor.constraint(equalTo: view.trailingAnchor).isActive = true
-        searchBar.topAnchor.constraint(equalTo: toolBar.bottomAnchor).isActive = true
+        searchBar.topAnchor.constraint(equalTo: toolBar.bottomAnchor, constant: Self.toolBarBottomMargin).isActive =
+            true
 
         bannerSlot.leadingAnchor.constraint(equalTo: view.leadingAnchor).isActive = true
         bannerSlot.trailingAnchor.constraint(equalTo: view.trailingAnchor).isActive = true

--- a/OpenDocumentReader/Main.storyboard
+++ b/OpenDocumentReader/Main.storyboard
@@ -58,10 +58,6 @@
                                             </barButtonItem>
                                         </items>
                                     </toolbar>
-                                    <view hidden="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sIx-zo-9kG" customClass="PageTabBar" customModule="OpenDocumentReader" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="0.0"/>
-                                        <color key="backgroundColor" systemColor="secondarySystemBackgroundColor"/>
-                                    </view>
                                     <progressView hidden="YES" opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="750" progress="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ePk-bQ-fV8">
                                         <rect key="frame" x="0.0" y="0.0" width="414" height="0.0"/>
                                     </progressView>
@@ -86,6 +82,10 @@
                                 <constraints>
                                     <constraint firstAttribute="height" constant="50" id="eXE-Ks-sQc"/>
                                 </constraints>
+                            </view>
+                            <view hidden="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sIx-zo-9kG" customClass="PageTabBar" customModule="OpenDocumentReader" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="190" width="414" height="0.0"/>
+                                <color key="backgroundColor" systemColor="secondarySystemBackgroundColor"/>
                             </view>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="HAk-oU-gAF"/>

--- a/OpenDocumentReader/Main.storyboard
+++ b/OpenDocumentReader/Main.storyboard
@@ -32,18 +32,11 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <view hidden="YES" contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="sKS-nk-f6M">
-                                <rect key="frame" x="0.0" y="0.0" width="0.0" height="44"/>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                <accessibility key="accessibilityConfiguration">
-                                    <accessibilityTraits key="traits" notEnabled="YES"/>
-                                </accessibility>
-                            </view>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="9mi-yf-jXf">
-                                <rect key="frame" x="0.0" y="0.0" width="414" height="88"/>
+                                <rect key="frame" x="0.0" y="44" width="414" height="44"/>
                                 <subviews>
                                     <toolbar opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="N1x-QM-Qks">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="88"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                                         <items>
                                             <barButtonItem title="Back to documents" id="yhO-7V-lbn">
                                                 <connections>
@@ -96,14 +89,10 @@
                             </view>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="HAk-oU-gAF"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="9mi-yf-jXf" firstAttribute="leading" secondItem="HAk-oU-gAF" secondAttribute="leading" id="5Hh-GZ-aPw"/>
-                            <constraint firstItem="sKS-nk-f6M" firstAttribute="top" secondItem="SIE-Uh-Zny" secondAttribute="top" id="HjQ-CN-3cF"/>
-                            <constraint firstItem="N1x-QM-Qks" firstAttribute="top" secondItem="9mi-yf-jXf" secondAttribute="top" id="Yiq-pe-hl5"/>
-                            <constraint firstItem="N1x-QM-Qks" firstAttribute="bottom" secondItem="sKS-nk-f6M" secondAttribute="bottom" constant="44" id="fDF-Mx-Nxy"/>
-                            <constraint firstItem="sKS-nk-f6M" firstAttribute="bottom" secondItem="HAk-oU-gAF" secondAttribute="top" id="gWh-EO-FK9"/>
-                            <constraint firstItem="9mi-yf-jXf" firstAttribute="top" secondItem="SIE-Uh-Zny" secondAttribute="top" id="rED-wA-6gv"/>
+                            <constraint firstItem="9mi-yf-jXf" firstAttribute="top" secondItem="HAk-oU-gAF" secondAttribute="top" id="rED-wA-6gv"/>
                             <constraint firstItem="9mi-yf-jXf" firstAttribute="trailing" secondItem="HAk-oU-gAF" secondAttribute="trailing" id="tPc-vX-Egd"/>
                         </constraints>
                     </view>


### PR DESCRIPTION
A user reported that the buttons above an open document overlap the system bar, and that there is a gap between them and the ad below.

Both come from one constraint. The tool bar was sized to `safe area top + 44` and pinned to the *top* of the view — a 2019 trick for reaching under the notch, which held as long as `UIToolbar` laid its items out along the bottom of an over-tall frame. iOS 26 lays them out along the top instead, so:

- the buttons landed on the status bar, clipped by the top of the screen;
- the rest of the bar — over 50 points on a notched phone — was an empty band between the buttons and whatever came next: the banner in the free edition, the document itself in the paid one.

The bar is now its own height, pinned to the safe area, which is where every version of iOS puts a bar's content anyway. The hidden measuring-stick view the trick needed goes with it, and the root view takes `systemBackground` instead of hardcoded white, since the strip behind the status bar is now its background rather than the bar's.

One thing does not follow from that. From iOS 26 the buttons are glass capsules that fill the bar's whole height, so anything pinned to its bottom edge meets them with nothing in between and cuts them off. They get 8 points of room there, and nothing before iOS 26, where the bar has a background of its own and the same margin only shows as a band of nothing.

## Checked in the simulator

Both editions, on both sides of the change in bar layout — iPhone 17 Pro on iOS 26.0 and iPhone 16 Pro on iOS 18.4, opening `test.odt`:

| | iOS 26 | iOS 18.4 |
| --- | --- | --- |
| paid | buttons clear of the status bar, document straight below the bar | unchanged from before: bar under the status bar, document straight below |
| free | buttons clear, 8pt, then the banner (live test ad) | banner flush under the bar, no stray band |

Geometry was measured directly off the view as well, at a 59pt safe area inset: the bar ran `0 … 157` before and runs `59 … 107` after, with the banner slot following it immediately. On iOS 17.5 and 18.4 the bar comes out 44 points tall and on iOS 26 48, in both cases starting at the safe area top.

The unit tests pass on iOS 18.4, and `scripts/format.sh --check` is clean.

Screenshots of all four combinations are in the working tree but deliberately not committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)