### PR TITLE
Give the viewer a back chevron and a pencil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ once the version tag exists.
 
 ## [Unreleased]
 
+### Changed
+
+- The way out of a document is a back chevron, not the words "Back to
+  documents".
+- Documents that can be edited offer a pencil next to the search button.
+  Editing has left the menu, which is where it used to hide.
+
 ### Fixed
 
 - The buttons above an open document no longer sit on the status bar, and the

--- a/OpenDocumentReader/DocumentViewController.swift
+++ b/OpenDocumentReader/DocumentViewController.swift
@@ -51,6 +51,13 @@ class DocumentViewController: UIViewController, DocumentDelegate, UISearchBarDel
     @IBOutlet weak var bannerSlotHeight: NSLayoutConstraint!
     @IBOutlet weak var barButtonItem: UIBarButtonItem!
     @IBOutlet weak var searchButton: UIBarButtonItem!
+    @IBOutlet weak var editButton: UIBarButtonItem!
+
+    /// The bar as the storyboard has it, and the same without the edit button.
+    /// Taken before anything is removed, since that is the only moment both are
+    /// there to be read.
+    private lazy var toolBarItems: [UIBarButtonItem] = toolBar.items ?? []
+    private lazy var toolBarItemsWithoutEdit: [UIBarButtonItem] = toolBarItems.filter { $0 !== editButton }
 
     /// Fills the banner slot when no ad does. Sits on top of `bannerSlot` rather than in the
     /// layout chain, so the slot keeps its height and nothing below it moves.
@@ -93,7 +100,13 @@ class DocumentViewController: UIViewController, DocumentDelegate, UISearchBarDel
         setVCconstraints()
         hideSearchBar()
 
-        barButtonItem.title = NSLocalizedString("back_to_documents", comment: "")
+        // the chevron says where it goes; the words are for VoiceOver, which is
+        // the one reader a glyph is no shorter for
+        barButtonItem.accessibilityLabel = NSLocalizedString("back_to_documents", comment: "")
+        editButton.accessibilityLabel = NSLocalizedString("menu_edit", comment: "")
+
+        // nothing is editable until a document says so
+        showEditButton(false)
 
         setUpHouseAd()
     }
@@ -323,6 +336,20 @@ class DocumentViewController: UIViewController, DocumentDelegate, UISearchBarDel
         findAll(searchText: searchText)
     }
 
+    @IBAction func editButton(_ sender: UIBarButtonItem) {
+        editDocument()
+    }
+
+    /// In the bar for the documents that can be edited, and only while they are
+    /// not being edited already. Every other document keeps the room for itself.
+    private func showEditButton(_ show: Bool) {
+        toolBar.items = show ? toolBarItems : toolBarItemsWithoutEdit
+    }
+
+    private func updateEditButton() {
+        showEditButton((document?.isEditable ?? false) && !(document?.edit ?? false))
+    }
+
     @IBAction func searchButton(_ sender: UIBarButtonItem) {
         AnalyticsManager.shared.report("menu_search")
         AnalyticsManager.shared.report(AnalyticsConstants.eventSearch)
@@ -422,14 +449,7 @@ class DocumentViewController: UIViewController, DocumentDelegate, UISearchBarDel
     @IBAction func showMenu(_ sender: Any) {
         let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
 
-        if (document?.isEditable ?? false) && !(document?.edit ?? false) {
-            alert.addAction(
-                UIAlertAction(
-                    title: NSLocalizedString("menu_edit", comment: ""), style: .default,
-                    handler: { (_) in
-                        self.editDocument()
-                    }))
-        }
+        // editing is not in here: it is the pencil in the bar
 
         if document?.edit ?? false {
             alert.addAction(
@@ -606,6 +626,7 @@ class DocumentViewController: UIViewController, DocumentDelegate, UISearchBarDel
             self.webview.loadFileURL(doc.fileURL, allowingReadAccessTo: doc.fileURL)
 
             searchButton.isEnabled = false
+            showEditButton(false)
 
             AnalyticsManager.shared.report(
                 "load_success",
@@ -637,12 +658,17 @@ class DocumentViewController: UIViewController, DocumentDelegate, UISearchBarDel
         // only what odrcore translated is searchable, and a later parse — after
         // a password, say — may well get there
         searchButton.isEnabled = true
+
+        // whether this one can be edited is not known until it is parsed
+        showEditButton(false)
     }
 
     func documentLoadingCompleted(_ doc: Document) {
         AnalyticsManager.shared.report("load_odf_success")
 
         progressBar.isHidden = true
+
+        updateEditButton()
 
         let fileType = doc.fileURL.pathExtension.lowercased()
 

--- a/OpenDocumentReader/Main.storyboard
+++ b/OpenDocumentReader/Main.storyboard
@@ -38,12 +38,18 @@
                                     <toolbar opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="N1x-QM-Qks">
                                         <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                                         <items>
-                                            <barButtonItem title="Back to documents" id="yhO-7V-lbn">
+                                            <barButtonItem image="chevron.backward" catalog="system" id="yhO-7V-lbn">
                                                 <connections>
                                                     <action selector="returnToDocuments:" destination="M2k-L8-Olo" id="ILH-TV-slT"/>
                                                 </connections>
                                             </barButtonItem>
                                             <barButtonItem style="plain" systemItem="flexibleSpace" id="lgr-dX-fUO"/>
+                                            <barButtonItem image="pencil" catalog="system" id="Ed1-tP-enc">
+                                                <connections>
+                                                    <action selector="editButton:" destination="M2k-L8-Olo" id="Ed2-tP-enc"/>
+                                                </connections>
+                                            </barButtonItem>
+                                            <barButtonItem width="10" style="plain" systemItem="fixedSpace" id="Ed4-tP-enc"/>
                                             <barButtonItem title="Search Button" image="magnifyingglass" catalog="system" id="fGi-i7-iOR">
                                                 <connections>
                                                     <action selector="searchButton:" destination="M2k-L8-Olo" id="6fS-of-qcB"/>
@@ -100,6 +106,7 @@
                         <outlet property="bannerSlot" destination="yut-lR-gq5" id="28Z-1b-NAN"/>
                         <outlet property="bannerSlotHeight" destination="eXE-Ks-sQc" id="yQ1-l7-wiV"/>
                         <outlet property="barButtonItem" destination="yhO-7V-lbn" id="ach-z7-H9P"/>
+                        <outlet property="editButton" destination="Ed1-tP-enc" id="Ed3-tP-enc"/>
                         <outlet property="menuButton" destination="Vsd-IL-ujz" id="GoN-tp-egn"/>
                         <outlet property="pageTabBar" destination="sIx-zo-9kG" id="pCn-x0-Z01"/>
                         <outlet property="progressBar" destination="ePk-bQ-fV8" id="nz6-qw-ouf"/>
@@ -213,8 +220,10 @@
         </scene>
     </scenes>
     <resources>
+        <image name="chevron.backward" catalog="system" width="76" height="128"/>
         <image name="ellipsis" catalog="system" width="128" height="37"/>
         <image name="magnifyingglass" catalog="system" width="128" height="115"/>
+        <image name="pencil" catalog="system" width="128" height="127"/>
         <systemColor name="secondarySystemBackgroundColor">
             <color red="0.94901960780000005" green="0.94901960780000005" blue="0.96862745100000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>


### PR DESCRIPTION
Stacked on #155 — review that one first; this branch only adds the commit on top of it.

Two things about the buttons above an open document.

**"Back to documents" is long.** It spelled out what a chevron says, and took a third of the bar to do it. It is `chevron.backward` now. The words stay as the accessibility label rather than being dropped: a glyph is no shorter for VoiceOver, and it keeps the string that is already translated into all 16 languages doing something — a short "Back" would have been a new key, English everywhere until someone translates it.

**Editing was three taps deep**, in the "…" menu, even for the documents that can take it. It is a pencil in the bar now, next to search, the way Android has had it for years. It appears only where it applies: the bar loses the button while a document is being parsed and gets it back only if odrcore says the result can be written back. Editing leaves the menu with it, so there is one way to reach it rather than two.

The bar keeps the room for the pencil only where it is earned — the chevron is what pays for it.

## Checked in the simulator

iPhone 17 Pro on iOS 26.0 and iPhone 16 Pro on iOS 18.4, both showing the same four evenly spaced buttons — chevron on the left, pencil / search / menu on the right:

- **`test.odt`** — pencil is there. Tapping it re-parses the document as editable and the pencil goes away, since the document is already being edited; the menu then offers Save and Discard changes, and no longer offers Edit.
- **`test.csv`** — no pencil. odrcore renders it but cannot write it back, so there is nothing to elevate.

The unit tests pass and `scripts/format.sh --check` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)