### PR TITLE
Fit a document to the screen, as Android does

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ once the version tag exists.
 
 ### Changed
 
+- A document wider than the screen opens fitted to it rather than running off
+  the edge, which is what it has always done on Android.
 - The way out of a document is a back chevron, not the words "Back to
   documents".
 - Documents that can be edited offer a pencil next to the search button.

--- a/OpenDocumentReader/CoreWrapper.swift
+++ b/OpenDocumentReader/CoreWrapper.swift
@@ -128,15 +128,23 @@ private func isCsv(_ file: DecodedFile) -> Bool { file.fileType == .commaSeparat
             throw coreWrapperError(.unsupportedFileType, "not a document file")
         }
 
+        // the same answers OpenDocument.droid gives odrcore, so a document is
+        // the same document on both — the viewport meta each page carries is
+        // decided from these
         let config = HtmlConfig()
         config.editable = editable
         // resource paths are resolved relative to an output directory, and in
         // server mode there is none — odrcore rejects the combination
         config.relativeResourcePaths = false
-        // the side margins of a printed page, which is what it was written to look like
+        // the side margins of a printed page, which is what it was written to
+        // look like, and what makes odrcore call a text document paged: its
+        // pages are then fitted to the screen rather than shown at full size
         config.textDocumentMargin = true
-        // served with the pages rather than inlined as base64, as in OpenDocument.droid
+        // served with the pages rather than inlined as base64
         config.embedImages = false
+        // odrcore's own css and js go into the page: there is no output
+        // directory to put them beside
+        config.embedShippedResources = true
 
         let documentType: DocumentType
         let openedDocument: OdrCoreObjC.Document?

--- a/OpenDocumentReader/DocumentViewController.swift
+++ b/OpenDocumentReader/DocumentViewController.swift
@@ -59,6 +59,29 @@ class DocumentViewController: UIViewController, DocumentDelegate, UISearchBarDel
     private lazy var toolBarItems: [UIBarButtonItem] = toolBar.items ?? []
     private lazy var toolBarItemsWithoutEdit: [UIBarButtonItem] = toolBarItems.filter { $0 !== editButton }
 
+    /// What OpenDocument.droid gets from `loadWithOverviewMode`, which iOS has
+    /// no setting for: a page wider than the screen is zoomed out until it fits
+    /// instead of running off the edge.
+    ///
+    /// odrcore asks for that by leaving the initial scale out of the viewport
+    /// meta - `width=device-width` alone, which every browser but a web view in
+    /// overview mode reads as "lay out at screen width and let the rest
+    /// overflow". A page that names its scale (a spreadsheet, a csv) means it,
+    /// and is left alone.
+    private static let fitToWidthScript = """
+        (function () {
+            var meta = document.querySelector('meta[name="viewport"]');
+            if (!meta || (meta.content || '').indexOf('initial-scale') !== -1) {
+                return;
+            }
+
+            var width = document.documentElement.scrollWidth;
+            if (width > window.innerWidth) {
+                meta.setAttribute('content', 'width=' + width + ',user-scalable=yes');
+            }
+        })();
+        """
+
     /// Fills the banner slot when no ad does. Sits on top of `bannerSlot` rather than in the
     /// layout chain, so the slot keeps its height and nothing below it moves.
     private let houseAdView = HouseAdView()
@@ -91,6 +114,8 @@ class DocumentViewController: UIViewController, DocumentDelegate, UISearchBarDel
         // would fight the first
         pageTabBar.addTarget(self, action: #selector(pageSelected(sender:)), for: .valueChanged)
         webview.navigationDelegate = self
+        webview.configuration.userContentController.addUserScript(
+            WKUserScript(source: Self.fitToWidthScript, injectionTime: .atDocumentEnd, forMainFrameOnly: true))
 
         searchBar.delegate = self
         searchBar.showsCancelButton = true

--- a/OpenDocumentReader/DocumentViewController.swift
+++ b/OpenDocumentReader/DocumentViewController.swift
@@ -68,8 +68,19 @@ class DocumentViewController: UIViewController, DocumentDelegate, UISearchBarDel
     /// overview mode reads as "lay out at screen width and let the rest
     /// overflow". A page that names its scale (a spreadsheet, a csv) means it,
     /// and is left alone.
-    private static let fitToWidthScript = """
+    ///
+    /// Only for what odrcore served, which is why `origin` is checked here as
+    /// well as before the script is installed: the same web view shows the
+    /// formats odrcore does not handle, and follows links out of a document.
+    /// Their viewport is their author's to write, and rewriting it would throw
+    /// away what it says - `user-scalable=no`, a maximum scale, a `viewport-fit`.
+    private static func fitToWidthScript(servedFrom origin: String) -> String {
+        """
         (function () {
+            if (location.origin !== '\(origin)') {
+                return;
+            }
+
             var meta = document.querySelector('meta[name="viewport"]');
             if (!meta || (meta.content || '').indexOf('initial-scale') !== -1) {
                 return;
@@ -81,6 +92,27 @@ class DocumentViewController: UIViewController, DocumentDelegate, UISearchBarDel
             }
         })();
         """
+    }
+
+    /// Arms ``fitToWidthScript(servedFrom:)`` for a page that came off our own
+    /// server, and disarms it for anything else. At document end rather than on
+    /// `didFinish`, so the page is fitted before it is first drawn instead of
+    /// jumping once the images are in.
+    private func installFitToWidth(for url: URL) {
+        let scripts = webview.configuration.userContentController
+        scripts.removeAllUserScripts()
+
+        guard CoreWrapper.isServedURL(url),
+            let scheme = url.scheme, let host = url.host, let port = url.port
+        else {
+            return
+        }
+
+        scripts.addUserScript(
+            WKUserScript(
+                source: Self.fitToWidthScript(servedFrom: "\(scheme)://\(host):\(port)"),
+                injectionTime: .atDocumentEnd, forMainFrameOnly: true))
+    }
 
     /// Fills the banner slot when no ad does. Sits on top of `bannerSlot` rather than in the
     /// layout chain, so the slot keeps its height and nothing below it moves.
@@ -114,8 +146,6 @@ class DocumentViewController: UIViewController, DocumentDelegate, UISearchBarDel
         // would fight the first
         pageTabBar.addTarget(self, action: #selector(pageSelected(sender:)), for: .valueChanged)
         webview.navigationDelegate = self
-        webview.configuration.userContentController.addUserScript(
-            WKUserScript(source: Self.fitToWidthScript, injectionTime: .atDocumentEnd, forMainFrameOnly: true))
 
         searchBar.delegate = self
         searchBar.showsCancelButton = true
@@ -596,6 +626,8 @@ class DocumentViewController: UIViewController, DocumentDelegate, UISearchBarDel
 
             return
         }
+
+        installFitToWidth(for: url)
 
         // pages come off the loopback server; a file URL needs read access
         // granted along with it


### PR DESCRIPTION
Stacked on #156, which is stacked on #155 — this branch adds only its own commit.

## What the two apps actually send odrcore

`CoreLoader.kt` and `CoreWrapper.swift`, side by side:

| | OpenDocument.droid | here, before | here, now |
| --- | --- | --- | --- |
| `embedImages` | false | false | false |
| `embedShippedResources` | true | *unset* (default true) | true |
| `relativeResourcePaths` | false | false | false |
| `textDocumentMargin` | the pagination setting, default **true** | true | true |
| `editable` | editable | editable | editable |
| viewport | *unset* → `automatic` | *unset* → `automatic` | *unset* → `automatic` |

So the config was already the same in effect, on the same odrcore (6.6.0) — `embedShippedResources` is the one line that was left implicit, and it is spelled out now. Android's `textDocumentMargin` follows a user setting we have no equivalent for; its default is `true`, which is what we pass.

The HTML that comes back is therefore identical. I checked what odrcore emits for each fixture:

| fixture | viewport meta |
| --- | --- |
| `test.odt` | `width=device-width,user-scalable=yes` |
| `test.odp` | `width=device-width,user-scalable=yes` |
| `test.ods` | `width=device-width,initial-scale=1.0,user-scalable=yes` |
| `test.csv` | `width=device-width,initial-scale=1.0,user-scalable=yes` |

Paged content leaves the scale out on purpose; reflowing content names it.

## Where the two readers part

Leaving the scale out only means "fit the width" to a web view in overview mode. `PageView.kt` sets `loadWithOverviewMode = true` and `useWideViewPort = true`, so Android zooms a page out until its full width is on screen. WKWebView has no such setting and reads `width=device-width` literally: lay out at screen width, let the rest overflow. A letter-wide page ran off the right edge of every iPhone — the clipped text is visible in the screenshots on #155.

A script at document end gives the viewport meta the width the page actually needs, which is overview mode by the only means iOS has. A page that names its own scale is left alone, so spreadsheets and csvs still open at 100% exactly as they do on Android.

## Checked in the simulator

iPhone 17 Pro on iOS 26.0 and iPhone 16 Pro on iOS 18.4:

- **`test.odt`** — the page now fits the screen with odrcore's gutter around it, and full lines are readable instead of being cut off mid-sentence. Pinch to zoom still works.
- **`test.ods`** — unchanged, opens at actual size.

Unit tests pass and `scripts/format.sh --check` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)