### PR TITLE
Cut 1.39's heading and write 1.40's store copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ open: **a second build under the same version goes under the already cut
 heading, not back under `Unreleased`.** Date the heading and add its compare link
 once the version tag exists.
 
-## [Unreleased]
+## [1.40]
 
 ### Changed
 

--- a/fastlane/metadata/en-US/changelogs/1.40.txt
+++ b/fastlane/metadata/en-US/changelogs/1.40.txt
@@ -1,0 +1,4 @@
+- A document opens fitted to the screen instead of running off the edge
+- The buttons above a document no longer sit on the status bar, and the empty band below them is gone
+- Editing a document is a pencil next to the search button, rather than something to find in the menu
+- The way back to your documents is a chevron, as everywhere else


### PR DESCRIPTION
Everything under `Unreleased` has landed, so it is a version: `## [Unreleased]` becomes `## [1.40]`, and `fastlane/metadata/en-US/changelogs/1.40.txt` holds the "What's New" copy for it.

What 1.40 is:

| | |
| --- | --- |
| #155 | the tool bar sat on the status bar, with an empty band between its buttons and the document |
| #156 | a back chevron instead of "Back to documents", and a pencil for the documents that can be edited |
| #157 | a document opens fitted to the screen instead of running off the edge, as it does on Android |

No date and no compare link on the heading, and `[Unreleased]` stays on `v1.39...HEAD`: the tag is written when the drafted release is published, which is what `CHANGELOG.md` says to wait for.

Both release scripts were run against this branch, since they are what a dispatch would hit first:

```
$ .github/scripts/resolve-version.py --input 1.40 --dry-run false
building 1.40

$ .github/scripts/changelog-section.py --version 1.40
### Changed
- A document wider than the screen opens fitted to it rather than running off
  the edge, which is what it has always done on Android.
…
```

That section is what the GitHub release body becomes.

Once this is merged: `gh workflow run release.yml -f version=1.40`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)