### PR TITLE
Take odrcore 6.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,13 @@ once the version tag exists.
 
 ### Changed
 
+- The engine is odrcore 6.7.1, up from 6.6.0. A pdf, a text file and an archive
+  listing can be searched, not only a document. A pdf's text also sits where the
+  file puts it: words no longer drift to the right of where they belong, bold
+  and italic are bold and italic, and a hit is highlighted in one piece.
 - PDFs are rendered by odrcore instead of being handed to the web view, and a
-  password protected one takes the prompt the other formats use. Their text is
-  in the page, so they become searchable once odrcore writes the search script
-  for a pdf page as it does for a document.
+  password protected one takes the prompt the other formats use. They can be
+  searched like a document, and a hit tints the text rather than covering it.
 - The search button leaves the tool bar when the page cannot be searched,
   rather than greying out - the same as the edit button.
 - The pencil turns into a save button while editing, as on Android. Saving from
@@ -41,11 +44,8 @@ once the version tag exists.
   for the onboarding buttons, the privacy screen and the banner, and Danish,
   Catalan, Turkish and Czech showed it for most of the rest.
 - The Chinese introduction named a different app.
-
-### Known issues
-
-- Tapping a document sets no cursor, so edit mode cannot be typed into. The
-  cause is in odrcore; `EditWorkflowTests` pins it until the fix ships.
+- Tapping a document sets the cursor, so an edit can be typed. The keyboard
+  never came up before.
 
 ## [1.40]
 

--- a/OpenDocumentReader.xcodeproj/project.pbxproj
+++ b/OpenDocumentReader.xcodeproj/project.pbxproj
@@ -713,7 +713,7 @@
 			repositoryURL = "https://github.com/opendocument-app/OpenDocument.core.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 6.6.0;
+				minimumVersion = 6.7.1;
 			};
 		};
 		AD584FCD41577C8CDEE974AA /* XCRemoteSwiftPackageReference "swift-package-manager-google-mobile-ads" */ = {

--- a/OpenDocumentReader.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OpenDocumentReader.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/opendocument-app/OpenDocument.core.git",
       "state" : {
-        "revision" : "c7b9c37b8436f3823fcc4213522218b6bc15c6b6",
-        "version" : "6.6.0"
+        "revision" : "82bbb3d4b4d596f2ab28f76611510baaf86d19da",
+        "version" : "6.7.1"
       }
     },
     {

--- a/OpenDocumentReaderTests/EditWorkflowTests.swift
+++ b/OpenDocumentReaderTests/EditWorkflowTests.swift
@@ -114,13 +114,7 @@ class EditWorkflowTests: XCTestCase {
                 })()
                 """) as? String
 
-        // odrcore 6.6.0 draws `.odr-page-outer` at `z-index:-1000`, which paints
-        // the page behind the column holding it; hit testing reads paint order,
-        // so every tap lands on that column. Delete this expectation - and it
-        // will insist on being deleted - once we ship a core without the rule.
-        XCTExpectFailure("the page is painted behind .odr-pages, which swallows the tap") {
-            XCTAssertEqual(tapped, "X-S")
-        }
+        XCTAssertEqual(tapped, "X-S")
     }
 
     /// Programmatic focus is not what the user does, but it proves the run is


### PR DESCRIPTION
6.6.0 to 6.7.1, skipping nothing — 6.7.0 was out for a day before 6.7.1 fixed what it uncovered.

## What comes with it

**Search reaches every view that renders text.** `odr.search()` and its
neighbours used to ship only with a document; now a pdf, a text file, an xml
view and an archive listing get them too, as `search.css` and `search.js`. We
link rather than embed, so the http server serves both — it already serves the
rest.

That closes the sentence the PDF entry in the changelog was left holding: it
said pdfs would become searchable *once* odrcore wrote the script for them. It
has, so the entry now says they are.

**A tap on a paged document lands on its text.** 6.6.0 painted `.odr-page-outer`
at `z-index:-1000`, which put the page behind the column holding it, and hit
testing reads paint order — so every tap went to the column and no caret was
set. `EditWorkflowTests` has been pinning that with an `XCTExpectFailure` since
we shipped it; the expectation comes out here, and it insists on coming out,
because a passing test under `XCTExpectFailure` fails the run.

**A pdf's text sits where the file puts it.** This is the 6.7.1 half. A
recovered word break was both written into the run and spanned by its offset,
so every word drifted another space to the right and a search hit landed on its
neighbour. Bold and italic in a non-embedded font were faked at the regular
cut's widths instead of being asked for by name. A line mixing fonts or sizes
put every run on the first run's baseline, which is what threw subscripts and
superscripts. And a hit running across words is now painted through the gaps
rather than in slivers.

## Checked

`EditWorkflowTests` is the whole of what changes on our side, and it is the one
test that has to be run against the new core rather than reasoned about — CI
does that.
