### PR TITLE
Open a document at the top of its own first page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ once the version tag exists.
   showed it for most of the rest.
 - Tapping a document sets the cursor, so an edit can be typed. The keyboard
   never came up before.
+- A document opens at the top of its first page. On a wide screen it opened far
+  enough down to cut off the heading.
 
 ### Removed
 

--- a/OpenDocumentReader/DocumentViewController.swift
+++ b/OpenDocumentReader/DocumentViewController.swift
@@ -108,10 +108,28 @@ class DocumentViewController: UIViewController, DocumentDelegate, UISearchBarDel
                 return;
             }
 
-            var width = document.documentElement.scrollWidth;
-            if (width > window.innerWidth) {
-                meta.setAttribute('content', 'width=' + width + ',user-scalable=yes');
+            var served = meta.content;
+            var natural = document.documentElement.scrollWidth;
+
+            // The web view's own width, which the viewport named below does not
+            // change: the visual viewport is that many CSS pixels at that scale.
+            function available() {
+                var seen = window.visualViewport;
+
+                return seen ? Math.round(seen.width * seen.scale) : window.innerWidth;
             }
+
+            function fit() {
+                meta.setAttribute(
+                    'content',
+                    natural > available() ? 'width=' + natural + ',user-scalable=yes' : served);
+            }
+
+            // On every resize, not just now: this first runs before the web view
+            // has the width it will keep, and a page held at a width it no
+            // longer needs is left scrolled off its own top.
+            fit();
+            window.addEventListener('resize', fit);
         })();
         """
     }


### PR DESCRIPTION
A pdf or a Word document opened part way down its own first page, with the heading cut off. On an iPad, every time.

## What was wrong

`fitToWidthScript` is injected at document end, which is before the web view has the size it will keep — at that moment it still has its storyboard width of 414 points. So it measured the page at 826 CSS pixels, concluded "wider than the screen", and pinned the viewport to `width=826`.

The iPad then lays out at 1032 points. That is *wider* than the page, so the page never needed pinning at all; and WebKit re-anchors the scroll across the resize, which left the document 137 pixels down. Enough to lose the invoice number on a pdf and the heading on a Word file.

The iPhone escaped it because 440 points really is narrower than 826, so the early answer happened to be right.

## What it does now

The available width comes from `visualViewport.width * scale`, which stays equal to the web view's own width no matter what viewport we have named — so the decision can be re-taken at any time without being confused by its own previous answer. It is re-taken on every `resize`, which also fixes rotation, and a page that fits is handed back the viewport odrcore served.

## Measured, not inferred

I instrumented the view and read the numbers off both devices rather than guessing from screenshots — three plausible-looking fixes had already failed because the scroll appears between 0.1s and 0.5s, after any of them ran.

| | before | after |
|---|---|---|
| iPad, settled | `width=826`, zoom 1.25, **scroll 137** | `width=device-width`, zoom 1.0, **scroll 0** |
| iPhone, settled | `width=826`, zoom 0.53, scroll 0 | unchanged |

Split out of #164, which is stacked on this — the iPad screenshots are wrong without it, but the bug has nothing to do with screenshots and shouldn't wait behind them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
