### PR TITLE
Call the Lite app what it is already called

### DIFF
--- a/fastlane/metadata-lite/all/name.txt
+++ b/fastlane/metadata-lite/all/name.txt
@@ -1,1 +1,1 @@
-OpenDocument Reader
+OpenDocument Reader - view ODT


### PR DESCRIPTION
`listing (lite)` failed in the 1.41 release:

```
[!] An exception has occurred for locale: en-US.
Error: The provided entity includes an attribute with a value that has already been
used on a different account. - The app name you entered is already being used
```

`fastlane/metadata-lite/all/name.txt` asked for `OpenDocument Reader`. That name
belongs to an account that is not ours, and searching the store does not find it -
a name can be reserved on a record that never ships, and it blocks everyone else
while staying invisible.

The file now asks for `OpenDocument Reader - view ODT`, which is what the app is
already called, so this asserts the current name rather than changing anything.
Thirty characters exactly, which is the store's limit.

`name.txt` arrived with the store copy in #162 and had never been uploaded until
this release, which is why no earlier run caught it. `${name}` is used nowhere in
the metadata - the only fill-in is `${ads}` - so nothing else reads this file.

Pro was unaffected: it asks for `OpenDocument Reader Pro`, which went through.

## Checked

`store_listing.py --version 1.41` still stages and passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)