### PR TITLE
Fail the release when the screenshots went up twice

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -355,6 +355,11 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
+      # One app at a time. Both listings carry the same 132 pictures, and run
+      # together they were pushing 264 at App Store Connect at once - enough of
+      # them came back failed that deliver uploaded them again, which is how a
+      # locale ends up holding the same screenshot three times.
+      max-parallel: 1
       matrix:
         include:
           - app: pro
@@ -382,13 +387,30 @@ jobs:
           name: framed
           path: fastlane/framed
 
+      # Kept, because the check below reads it. `tee` rather than a redirect so
+      # the step still shows what it is doing while it runs.
       - name: write ${{ matrix.app }}'s listing
         env:
           ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
           ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
           ASC_KEY_CONTENT: ${{ secrets.ASC_KEY_CONTENT }}
           ODR_VERSION: ${{ steps.version.outputs.version }}
-        run: bundle exec fastlane ios ${{ matrix.lane }}
+        run: |
+          set -o pipefail
+          bundle exec fastlane ios ${{ matrix.lane }} 2>&1 | tee listing.log
+
+      # A picture that did not land is uploaded again, and if the delete of the
+      # failed one does not take, the store keeps both. That leaves a locale
+      # showing the same screenshot twice, which nothing else here would notice
+      # - deliver reports the run as a success. So the retry itself is the
+      # failure: the pictures are up either way, and this says to go and look.
+      - name: the screenshots went up once each
+        run: |
+          set -euo pipefail
+          if grep -q "Failed to upload all screenshots" listing.log; then
+            echo "::error::deliver retried the screenshot upload, which can leave duplicates in App Store Connect. Check ${{ matrix.app }}'s screenshots for every locale before submitting, and re-run this job to upload the set again."
+            exit 1
+          fi
 
   record:
     needs: upload

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -355,11 +355,6 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
-      # One app at a time. Both listings carry the same 132 pictures, and run
-      # together they were pushing 264 at App Store Connect at once - enough of
-      # them came back failed that deliver uploaded them again, which is how a
-      # locale ends up holding the same screenshot three times.
-      max-parallel: 1
       matrix:
         include:
           - app: pro

--- a/README.md
+++ b/README.md
@@ -136,8 +136,9 @@ same sources built as two targets, one of which links no ad sdk.
 **If a `listing` job fails saying the screenshots did not go up once each**, the
 set is up but a locale may hold a picture twice: deliver uploads what it thinks
 did not land, and a delete that does not take leaves both. Look at the app's
-screenshots in App Store Connect, and re-run that job - it clears the set before
-it uploads, so a clean pass fixes it.
+screenshots in App Store Connect, and fix the set before submitting. Re-running
+the job is worth a try - it clears the set before it uploads - but it has come
+back doubled a second time, so check rather than assume.
 
 **If one app's upload fails, press "Re-run failed jobs".** Only that upload runs
 again, against the `.ipa` already built and signed - build number included, since

--- a/README.md
+++ b/README.md
@@ -133,6 +133,12 @@ It runs as five jobs:
 Both apps always go out together, and nothing chooses one: Pro and Lite are the
 same sources built as two targets, one of which links no ad sdk.
 
+**If a `listing` job fails saying the screenshots did not go up once each**, the
+set is up but a locale may hold a picture twice: deliver uploads what it thinks
+did not land, and a delete that does not take leaves both. Look at the app's
+screenshots in App Store Connect, and re-run that job - it clears the set before
+it uploads, so a clean pass fixes it.
+
 **If one app's upload fails, press "Re-run failed jobs".** Only that upload runs
 again, against the `.ipa` already built and signed - build number included, since
 it is baked in at archive time - and `record` runs behind it once it lands.


### PR DESCRIPTION
1.41's listing went up with the same screenshot three times in some locales, on
both apps, and nothing said so. This makes the run say so.

## What happened

Each listing uploads 132 pictures - 6 per device, two devices, eleven locales.
Enough of them came back unfinished that deliver went round again:

```
21:25:56  Starting with the upload of screenshots...
21:26:01  Successfully deleted all screenshots
21:26:49  Failed to upload all screenshots... Tries remaining: 4
21:27:18  Failed to upload all screenshots... Tries remaining: 3
21:27:31  Failed to upload all screenshots... Tries remaining: 2
21:27:45  Successfully uploaded screenshots to App Store Connect
```

deliver does try not to duplicate: on a retry it skips anything whose checksum is
already up, and this run skipped 67. But it also deletes the ones it reads as
incomplete before uploading them again, and a delete that has not taken leaves
both. 219 uploads landed for 132 files, and the slots filled to the ten App Store
Connect allows: German iPhone held `02-text` three times, `03-sheet` and
`05-pdf` twice each.

It is not new. Yesterday's run retried once and uploaded 149 for 132 - seventeen
too many, quietly. Today it filled the cap, which is the only reason it was seen.

## Why the cause is still open

The first version of this branch uploaded one app at a time, on the reasoning
that both listings together put 264 pictures in front of App Store Connect. That
is wrong, and the run says so: re-running one app on its own, with the other long
finished, doubled them again - three retries, 216 uploads for 132. Yesterday both
ran together and retried once. The load does not line up, so the guess came out
rather than going in.

What is left is timing inside deliver: a screenshot that has not finished
processing when it looks reads as incomplete, and deleting one of those is a race
it can lose.

`sync_screenshots` is the other lever and is not taken here: it sits behind
`FASTLANE_ENABLE_BETA_DELIVER_SYNC_SCREENSHOTS`, and a release pipeline is the
wrong place for a beta flag.

## So this only checks

A retry is now a failed job. The pictures are up either way, so the point is that
somebody goes and looks before submitting - which is what did not happen
yesterday. The README says what to do when it fires, including that re-running
has not been enough on its own.

## Not checked against a real upload

The check cannot be exercised without an App Store Connect key. The yaml parses;
the grep is read but not run. The next release is the proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W2XM93Raj1jyvUuYmpQrcz
