### PR TITLE
Take odrcore 6.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ once the version tag exists.
 
 - A long document opens at the top of its first page on an iPad. It opened a
   page or more in.
+- Pictures in a Word or Excel file show, rather than a broken image.
 
 ## [1.41]
 

--- a/OpenDocumentReader.xcodeproj/project.pbxproj
+++ b/OpenDocumentReader.xcodeproj/project.pbxproj
@@ -830,7 +830,7 @@
 			repositoryURL = "https://github.com/opendocument-app/OpenDocument.core.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 6.10.0;
+				minimumVersion = 6.10.1;
 			};
 		};
 		AD584FCD41577C8CDEE974AA /* XCRemoteSwiftPackageReference "swift-package-manager-google-mobile-ads" */ = {

--- a/OpenDocumentReader.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OpenDocumentReader.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/opendocument-app/OpenDocument.core.git",
       "state" : {
-        "revision" : "9edbc14c1844cd432820b268f18e9b58e5a8b28a",
-        "version" : "6.10.0"
+        "revision" : "d1573b0cb8c9fd172b59ce785d40ba9ddb745ba2",
+        "version" : "6.10.1"
       }
     },
     {


### PR DESCRIPTION
odrcore 6.10.0 → 6.10.1, resolved against the tag.

## What it takes

The one change in the release is opendocument-app/OpenDocument.core#727: a linked image in a docx or xlsx is named relative to the document, as odf already did.

That is not a corner case here. The app asks for images to be served rather than written into the page (`embedImages = false`), and serves them from odrcore's own server under `/file/<prefix>/`. The ooxml engines resolved an image relationship to an absolute container path — `/word/media/image1.jpeg` — which `resource_at` matches against the request path by exact string, so it never matched. Every picture in a Word or Excel file is a broken image in the app today, in 1.41 and in 1.42 as it stands. ODF was always fine, which is what hid it.

Taken from the core's own regression test and the app's configuration, not observed on a device: the screenshot documents carry no images, so nothing here shows it.

Nothing to wire — the fix is entirely inside the core.

## Worth knowing before 1.42

This is the reason to hold the release rather than cut it now.
