### PR TITLE
Take odrcore 6.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ once the version tag exists.
 - A zip file opens and lists what is inside. Tapping an entry shows it.
 - Photos and text files the reader used to refuse now open.
 - Rich text files open.
+- Markdown files are shown as prose: a heading is a heading, and the hashes and
+  stars are gone.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ once the version tag exists.
 
 ### Changed
 
-- The engine is odrcore 7.0.0, up from 6.10.1.
+- The engine is odrcore 6.11.0, up from 6.10.1.
 - A file that will not open says so, and offers to write to us when something
   went wrong on our side.
 - The app no longer offers itself for music and films.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,12 +23,29 @@ once the version tag exists.
 
 - A zip file opens and lists what is inside. Tapping an entry shows it.
 - Photos and text files the reader used to refuse now open.
+- Rich text files open.
 
 ### Changed
 
+- The engine is odrcore 7.0.0, up from 6.10.1.
 - A file that will not open says so, and offers to write to us when something
   went wrong on our side.
 - The app no longer offers itself for music and films.
+- A link out of a document opens in the browser, rather than leading nowhere.
+- Slides show their colours: text, highlights and the fill behind a shape.
+- Text in a PDF no longer runs over the page in giant type, and can be selected,
+  searched and copied where it came out as Chinese, Japanese or Korean.
+- A PDF opens faster and zooms without stalling.
+- A tall spreadsheet keeps many more rows before it stops; a very wide one keeps
+  fewer.
+- A single-file OpenDocument shows the document, not its source.
+
+### Fixed
+
+- A file saved by the reader opens in LibreOffice again.
+- A presentation exported from Google Slides opens.
+- A Photoshop or JPEG 2000 file says it will not open, instead of showing a
+  blank page.
 
 ## [1.42]
 

--- a/OpenDocumentReader.xcodeproj/project.pbxproj
+++ b/OpenDocumentReader.xcodeproj/project.pbxproj
@@ -830,7 +830,7 @@
 			repositoryURL = "https://github.com/opendocument-app/OpenDocument.core.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 7.0.0;
+				minimumVersion = 6.11.0;
 			};
 		};
 		AD584FCD41577C8CDEE974AA /* XCRemoteSwiftPackageReference "swift-package-manager-google-mobile-ads" */ = {

--- a/OpenDocumentReader.xcodeproj/project.pbxproj
+++ b/OpenDocumentReader.xcodeproj/project.pbxproj
@@ -830,7 +830,7 @@
 			repositoryURL = "https://github.com/opendocument-app/OpenDocument.core.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 6.10.1;
+				minimumVersion = 7.0.0;
 			};
 		};
 		AD584FCD41577C8CDEE974AA /* XCRemoteSwiftPackageReference "swift-package-manager-google-mobile-ads" */ = {

--- a/OpenDocumentReader.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OpenDocumentReader.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/opendocument-app/OpenDocument.core.git",
       "state" : {
-        "revision" : "d1573b0cb8c9fd172b59ce785d40ba9ddb745ba2",
-        "version" : "6.10.1"
+        "revision" : "3fa5603c9093ac2df3ca0596d612ad11390e7f95",
+        "version" : "6.11.0"
       }
     },
     {

--- a/OpenDocumentReader/CoreWrapper.swift
+++ b/OpenDocumentReader/CoreWrapper.swift
@@ -91,6 +91,15 @@ private func selectViews(_ views: [HtmlView], _ documentType: DocumentType) -> [
     private var document: OdrCoreObjC.Document?
     private let lock = NSRecursiveLock()
 
+    /// The largest sheet region translated, as on OpenDocument.droid. The
+    /// encoding is written out because Swift has no `@encode`.
+    private static let spreadsheetLimit: NSValue = withUnsafeBytes(
+        of: TableDimensions(rows: 100_000, columns: 500)
+    ) { NSValue(bytes: $0.baseAddress!, objCType: "{ODRTableDimensions=II}") }
+
+    /// Bounds the rows by the sheet's width: the wider, the fewer it keeps.
+    private static let spreadsheetCellLimit: UInt64 = 500_000
+
     @objc func translate(
         _ inputPath: String,
         cache cachePath: String,
@@ -130,12 +139,6 @@ private func selectViews(_ views: [HtmlView], _ documentType: DocumentType) -> [
             throw coreWrapperError(.unsupportedFileType, "odrcore does not render this file type")
         }
 
-        // odrcore calls a file it recognises as nothing else text, so an unnamed
-        // charset means the bytes are not text at all
-        if file.isTextFile, (try? file.asTextFile())?.charset == nil {
-            throw coreWrapperError(.unsupportedFileType, "odrcore could not name a charset")
-        }
-
         // the same answers OpenDocument.droid gives odrcore, so a document is
         // the same document on both — the viewport meta each page carries is
         // decided from these
@@ -157,6 +160,12 @@ private func selectViews(_ views: [HtmlView], _ documentType: DocumentType) -> [
         // odrcore's own css and js go into the page: there is no output
         // directory to put them beside
         config.embedShippedResources = true
+        // a WKWebView fits no top-level document, so the view fits itself
+        config.viewportMode = .fitWidthByView
+        // stated rather than inherited: a sheet past the limit is cut off silently
+        config.spreadsheetLimit = Self.spreadsheetLimit
+        config.spreadsheetCellLimit = NSNumber(value: Self.spreadsheetCellLimit)
+        config.spreadsheetLimitByContent = true
 
         let documentType: DocumentType
         let openedDocument: OdrCoreObjC.Document?

--- a/OpenDocumentReader/CoreWrapper.swift
+++ b/OpenDocumentReader/CoreWrapper.swift
@@ -100,6 +100,28 @@ private func selectViews(_ views: [HtmlView], _ documentType: DocumentType) -> [
     /// Bounds the rows by the sheet's width: the wider, the fewer it keeps.
     private static let spreadsheetCellLimit: UInt64 = 500_000
 
+    /// As odrcore reads the bytes, or as the name says where that reading is
+    /// text. Markdown has no signature, so only the name can name it.
+    private func openFile(_ inputPath: String) throws -> DecodedFile {
+        let detected = try DecodedFile.decode(path: inputPath)
+        let declared = Odr.fileType(extension: URL(fileURLWithPath: inputPath).pathExtension)
+
+        guard declared != .unknown, declared != detected.fileType, detected.isTextFile,
+            nameOutranksText(declared)
+        else {
+            return detected
+        }
+
+        return (try? DecodedFile.decode(path: inputPath, as: declared)) ?? detected
+    }
+
+    /// A document, or a format odrcore cannot detect from its bytes. Csv is
+    /// neither: odrcore reads that out of the text itself.
+    private func nameOutranksText(_ declared: FileType) -> Bool {
+        Odr.fileCategory(fileType: declared) == .document
+            || !Odr.capabilities(fileType: declared).detectByContent
+    }
+
     @objc func translate(
         _ inputPath: String,
         cache cachePath: String,
@@ -120,7 +142,7 @@ private func selectViews(_ views: [HtmlView], _ documentType: DocumentType) -> [
             throw coreWrapperError(.unsupportedFileType, "odrcore does not recognise this file type")
         }
 
-        var file = try DecodedFile.decode(path: inputPath)
+        var file = try openFile(inputPath)
         if file.isPasswordEncrypted {
             do {
                 file = try file.decrypt(withPassword: password ?? "")
@@ -160,8 +182,6 @@ private func selectViews(_ views: [HtmlView], _ documentType: DocumentType) -> [
         // odrcore's own css and js go into the page: there is no output
         // directory to put them beside
         config.embedShippedResources = true
-        // a WKWebView fits no top-level document, so the view fits itself
-        config.viewportMode = .fitWidthByView
         // stated rather than inherited: a sheet past the limit is cut off silently
         config.spreadsheetLimit = Self.spreadsheetLimit
         config.spreadsheetCellLimit = NSNumber(value: Self.spreadsheetCellLimit)

--- a/OpenDocumentReader/DocumentViewController.swift
+++ b/OpenDocumentReader/DocumentViewController.swift
@@ -75,6 +75,105 @@ class DocumentViewController: UIViewController, DocumentDelegate, UISearchBarDel
         }
     }
 
+    /// What OpenDocument.droid gets from `loadWithOverviewMode`, which iOS has
+    /// no setting for: a page wider than the screen is zoomed out until it fits
+    /// instead of running off the edge.
+    ///
+    /// odrcore asks for that by leaving the initial scale out of the viewport
+    /// meta - `width=device-width` alone, which every browser but a web view in
+    /// overview mode reads as "lay out at screen width and let the rest
+    /// overflow". A page that names its scale (a spreadsheet, a csv) means it,
+    /// and is left alone.
+    ///
+    /// Only for what odrcore served, which is why `origin` is checked here as
+    /// well as before the script is installed: the same web view shows the
+    /// formats odrcore does not handle, and follows links out of a document.
+    /// Their viewport is their author's to write, and rewriting it would throw
+    /// away what it says - `user-scalable=no`, a maximum scale, a `viewport-fit`.
+    private static func fitToWidthScript(servedFrom origin: String) -> String {
+        """
+        (function () {
+            if (location.origin !== '\(origin)') {
+                return;
+            }
+
+            var meta = document.querySelector('meta[name="viewport"]');
+            if (!meta || (meta.content || '').indexOf('initial-scale') !== -1) {
+                return;
+            }
+
+            var served = meta.content;
+            var natural = document.documentElement.scrollWidth;
+
+            // The web view's own width, which the viewport named below does not
+            // change: the visual viewport is that many CSS pixels at that scale.
+            function available() {
+                var seen = window.visualViewport;
+
+                return seen ? Math.round(seen.width * seen.scale) : window.innerWidth;
+            }
+
+            function fit() {
+                meta.setAttribute(
+                    'content',
+                    natural > available() ? 'width=' + natural + ',user-scalable=yes' : served);
+            }
+
+            // Across a resize the browser keeps the reader's place by holding on
+            // to whatever was against the top of the screen, and here it gets it
+            // wrong: the scale changes with the width, and the page comes back
+            // hundreds of pixels down - a page or more of a long document on an
+            // iPad, which is where the width really does change. It settles
+            // there some frames after the resize, so the place the reader was
+            // actually at is re-asserted until it has finished, and dropped the
+            // moment they take hold of the page themselves.
+            var holding = [];
+
+            function hold(place) {
+                holding.forEach(clearTimeout);
+                holding = [0, 16, 50, 150, 300, 500].map(function (ms) {
+                    return setTimeout(function () { window.scrollTo(window.scrollX, place); }, ms);
+                });
+            }
+
+            window.addEventListener('touchstart', function () {
+                holding.forEach(clearTimeout);
+                holding = [];
+            }, { passive: true });
+
+            // On every resize, not just now: this first runs before the web view
+            // has the width it will keep, and a page held at a width it no
+            // longer needs is left scrolled off its own top.
+            fit();
+            window.addEventListener('resize', function () {
+                var was = window.scrollY;
+                fit();
+                hold(was);
+            });
+        })();
+        """
+    }
+
+    /// Arms ``fitToWidthScript(servedFrom:)`` for a page that came off our own
+    /// server, and disarms it for anything else. At document end rather than on
+    /// `didFinish`, so the page is fitted before it is first drawn instead of
+    /// jumping once the images are in.
+    private func installFitToWidth(for url: URL) {
+        let scripts = webview.configuration.userContentController
+        scripts.removeAllUserScripts()
+
+        guard CoreWrapper.isServedURL(url),
+            let scheme = url.scheme, let host = url.host, let port = url.port
+        else {
+            return
+        }
+
+        scripts.addUserScript(
+            WKUserScript(
+                source: Self.fitToWidthScript(servedFrom: "\(scheme)://\(host):\(port)"),
+                injectionTime: .atDocumentEnd, forMainFrameOnly: true))
+    }
+
     /// Fills the banner slot when no ad does. Sits on top of `bannerSlot` rather than in the
     /// layout chain, so the slot keeps its height and nothing below it moves.
     private let houseAdView = HouseAdView()
@@ -186,6 +285,7 @@ class DocumentViewController: UIViewController, DocumentDelegate, UISearchBarDel
             if let page = corePageInReserve {
                 corePageInReserve = nil
 
+                installFitToWidth(for: page)
                 documentNavigation = webview.load(URLRequest(url: page))
 
                 return
@@ -789,13 +889,14 @@ class DocumentViewController: UIViewController, DocumentDelegate, UISearchBarDel
             return
         }
 
+        installFitToWidth(for: url)
+
         documentNavigation = self.webview.load(URLRequest(url: url))
     }
 
-    /// Two files the system draws better, both falling back to `corePageInReserve`
-    /// when it turns out it cannot: a container the system knows as a document —
-    /// an `.epub` is composite content, a `.zip` is not — and iWork, whose text
-    /// odrcore reads but whose styles and pictures it does not.
+    /// Two the system draws better, both falling back to `corePageInReserve`:
+    /// a container it knows as a document (`.epub` is composite content, `.zip`
+    /// is not), and iWork, whose styles and pictures odrcore does not read.
     private func systemDrawsItBetter(_ doc: Document) -> Bool {
         let ext = doc.fileURL.pathExtension.lowercased()
 

--- a/OpenDocumentReader/DocumentViewController.swift
+++ b/OpenDocumentReader/DocumentViewController.swift
@@ -75,105 +75,6 @@ class DocumentViewController: UIViewController, DocumentDelegate, UISearchBarDel
         }
     }
 
-    /// What OpenDocument.droid gets from `loadWithOverviewMode`, which iOS has
-    /// no setting for: a page wider than the screen is zoomed out until it fits
-    /// instead of running off the edge.
-    ///
-    /// odrcore asks for that by leaving the initial scale out of the viewport
-    /// meta - `width=device-width` alone, which every browser but a web view in
-    /// overview mode reads as "lay out at screen width and let the rest
-    /// overflow". A page that names its scale (a spreadsheet, a csv) means it,
-    /// and is left alone.
-    ///
-    /// Only for what odrcore served, which is why `origin` is checked here as
-    /// well as before the script is installed: the same web view shows the
-    /// formats odrcore does not handle, and follows links out of a document.
-    /// Their viewport is their author's to write, and rewriting it would throw
-    /// away what it says - `user-scalable=no`, a maximum scale, a `viewport-fit`.
-    private static func fitToWidthScript(servedFrom origin: String) -> String {
-        """
-        (function () {
-            if (location.origin !== '\(origin)') {
-                return;
-            }
-
-            var meta = document.querySelector('meta[name="viewport"]');
-            if (!meta || (meta.content || '').indexOf('initial-scale') !== -1) {
-                return;
-            }
-
-            var served = meta.content;
-            var natural = document.documentElement.scrollWidth;
-
-            // The web view's own width, which the viewport named below does not
-            // change: the visual viewport is that many CSS pixels at that scale.
-            function available() {
-                var seen = window.visualViewport;
-
-                return seen ? Math.round(seen.width * seen.scale) : window.innerWidth;
-            }
-
-            function fit() {
-                meta.setAttribute(
-                    'content',
-                    natural > available() ? 'width=' + natural + ',user-scalable=yes' : served);
-            }
-
-            // Across a resize the browser keeps the reader's place by holding on
-            // to whatever was against the top of the screen, and here it gets it
-            // wrong: the scale changes with the width, and the page comes back
-            // hundreds of pixels down - a page or more of a long document on an
-            // iPad, which is where the width really does change. It settles
-            // there some frames after the resize, so the place the reader was
-            // actually at is re-asserted until it has finished, and dropped the
-            // moment they take hold of the page themselves.
-            var holding = [];
-
-            function hold(place) {
-                holding.forEach(clearTimeout);
-                holding = [0, 16, 50, 150, 300, 500].map(function (ms) {
-                    return setTimeout(function () { window.scrollTo(window.scrollX, place); }, ms);
-                });
-            }
-
-            window.addEventListener('touchstart', function () {
-                holding.forEach(clearTimeout);
-                holding = [];
-            }, { passive: true });
-
-            // On every resize, not just now: this first runs before the web view
-            // has the width it will keep, and a page held at a width it no
-            // longer needs is left scrolled off its own top.
-            fit();
-            window.addEventListener('resize', function () {
-                var was = window.scrollY;
-                fit();
-                hold(was);
-            });
-        })();
-        """
-    }
-
-    /// Arms ``fitToWidthScript(servedFrom:)`` for a page that came off our own
-    /// server, and disarms it for anything else. At document end rather than on
-    /// `didFinish`, so the page is fitted before it is first drawn instead of
-    /// jumping once the images are in.
-    private func installFitToWidth(for url: URL) {
-        let scripts = webview.configuration.userContentController
-        scripts.removeAllUserScripts()
-
-        guard CoreWrapper.isServedURL(url),
-            let scheme = url.scheme, let host = url.host, let port = url.port
-        else {
-            return
-        }
-
-        scripts.addUserScript(
-            WKUserScript(
-                source: Self.fitToWidthScript(servedFrom: "\(scheme)://\(host):\(port)"),
-                injectionTime: .atDocumentEnd, forMainFrameOnly: true))
-    }
-
     /// Fills the banner slot when no ad does. Sits on top of `bannerSlot` rather than in the
     /// layout chain, so the slot keeps its height and nothing below it moves.
     private let houseAdView = HouseAdView()
@@ -246,17 +147,20 @@ class DocumentViewController: UIViewController, DocumentDelegate, UISearchBarDel
         ])
     }
 
-    /// odrcore writes every link with `target="_blank"`, and this app has no
-    /// second window: what odrcore serves opens in the web view that asked.
+    /// Only a link that leaves the page carries `target="_blank"`, and this app
+    /// has no second window: the web goes to the browser, and what odrcore
+    /// serves — should any of it arrive here — to the web view that asked.
     func webView(
         _ webView: WKWebView, createWebViewWith configuration: WKWebViewConfiguration,
         for navigationAction: WKNavigationAction, windowFeatures: WKWindowFeatures
     ) -> WKWebView? {
-        guard let url = navigationAction.request.url, CoreWrapper.isServedURL(url) else {
-            return nil
-        }
+        guard let url = navigationAction.request.url else { return nil }
 
-        webView.load(navigationAction.request)
+        if CoreWrapper.isServedURL(url) {
+            webView.load(navigationAction.request)
+        } else if UIApplication.shared.canOpenURL(url) {
+            UIApplication.shared.open(url)
+        }
 
         return nil
     }
@@ -278,12 +182,11 @@ class DocumentViewController: UIViewController, DocumentDelegate, UISearchBarDel
         if !navigationResponse.canShowMIMEType {
             decisionHandler(.cancel)
 
-            // the system could not draw it after all, so fall back to the listing
-            if let listing = listingInReserve {
-                listingInReserve = nil
+            // the system could not draw it after all, so fall back to odrcore's
+            if let page = corePageInReserve {
+                corePageInReserve = nil
 
-                installFitToWidth(for: listing)
-                documentNavigation = webview.load(URLRequest(url: listing))
+                documentNavigation = webview.load(URLRequest(url: page))
 
                 return
             }
@@ -293,7 +196,7 @@ class DocumentViewController: UIViewController, DocumentDelegate, UISearchBarDel
             return
         }
 
-        listingInReserve = nil
+        corePageInReserve = nil
 
         guard let response = navigationResponse.response as? HTTPURLResponse,
             response.statusCode >= 400,
@@ -875,10 +778,9 @@ class DocumentViewController: UIViewController, DocumentDelegate, UISearchBarDel
             return
         }
 
-        // only a container to odrcore, but a document to the system: it gets
-        // the first go, with the listing kept in reserve
-        if doc.isArchive, systemKnowsItAsADocument(doc.fileURL) {
-            listingInReserve = url
+        // the system gets the first go, with odrcore's page kept in reserve
+        if systemDrawsItBetter(doc) {
+            corePageInReserve = url
 
             canEdit = false
             canSearch = false
@@ -887,21 +789,26 @@ class DocumentViewController: UIViewController, DocumentDelegate, UISearchBarDel
             return
         }
 
-        installFitToWidth(for: url)
-
         documentNavigation = self.webview.load(URLRequest(url: url))
     }
 
-    /// Whether the system's type for this file says document rather than
-    /// container: a `.pages` is composite content, a `.zip` is not.
-    private func systemKnowsItAsADocument(_ url: URL) -> Bool {
-        guard let type = UTType(filenameExtension: url.pathExtension) else { return false }
+    /// Two files the system draws better, both falling back to `corePageInReserve`
+    /// when it turns out it cannot: a container the system knows as a document —
+    /// an `.epub` is composite content, a `.zip` is not — and iWork, whose text
+    /// odrcore reads but whose styles and pictures it does not.
+    private func systemDrawsItBetter(_ doc: Document) -> Bool {
+        let ext = doc.fileURL.pathExtension.lowercased()
 
-        return !type.isDynamic && type.conforms(to: .compositeContent)
+        guard let type = UTType(filenameExtension: ext), !type.isDynamic else { return false }
+
+        return Self.iWorkExtensions.contains(ext)
+            || (doc.isArchive && type.conforms(to: .compositeContent))
     }
 
-    /// odrcore's listing, held back while the system has the first go.
-    private var listingInReserve: URL?
+    private static let iWorkExtensions: Set<String> = ["pages", "numbers", "key"]
+
+    /// odrcore's page, held back while the system has the first go.
+    private var corePageInReserve: URL?
 
     func documentEncrypted(_ doc: Document) {
         // the document is opened before this controller is presented, so the

--- a/OpenDocumentReader/DocumentViewController.swift
+++ b/OpenDocumentReader/DocumentViewController.swift
@@ -894,17 +894,23 @@ class DocumentViewController: UIViewController, DocumentDelegate, UISearchBarDel
         documentNavigation = self.webview.load(URLRequest(url: url))
     }
 
-    /// Two the system draws better, both falling back to `corePageInReserve`:
-    /// a container it knows as a document (`.epub` is composite content, `.zip`
-    /// is not), and iWork, whose styles and pictures odrcore does not read.
+    /// Three the system draws better, all falling back to `corePageInReserve`:
+    /// html, which odrcore has no type for and reads as its own source, iWork,
+    /// whose styles and pictures it does not read, and a container it knows as a
+    /// document (`.epub` is composite content, `.zip` is not).
     private func systemDrawsItBetter(_ doc: Document) -> Bool {
         let ext = doc.fileURL.pathExtension.lowercased()
 
         guard let type = UTType(filenameExtension: ext), !type.isDynamic else { return false }
 
-        return Self.iWorkExtensions.contains(ext)
+        return Self.webPageTypes.contains(where: type.conforms(to:))
+            || Self.iWorkExtensions.contains(ext)
             || (doc.isArchive && type.conforms(to: .compositeContent))
     }
+
+    /// Both, because `public.xhtml` conforms to xml rather than to html — and
+    /// xml is what a flat ODF is, which odrcore does render.
+    private static let webPageTypes: [UTType] = [.html, UTType("public.xhtml")].compactMap { $0 }
 
     private static let iWorkExtensions: Set<String> = ["pages", "numbers", "key"]
 

--- a/OpenDocumentReaderTests/ArchiveDocumentTests.swift
+++ b/OpenDocumentReaderTests/ArchiveDocumentTests.swift
@@ -97,8 +97,7 @@ class ArchiveDocumentTests: XCTestCase {
         XCTAssertFalse(shown.contains(NSLocalizedString("toast_error_generic", comment: "")), shown)
     }
 
-    /// A `.pages` is a zip to odrcore, but a document to the system, which gets
-    /// the first go.
+    /// odrcore reads a `.pages`, but only its text: the system gets the first go.
     func testADocumentTheSystemKnowsIsLeftToTheSystem() throws {
         try present(try copyFixture(ofType: "pages"))
 

--- a/OpenDocumentReaderTests/ArchiveDocumentTests.swift
+++ b/OpenDocumentReaderTests/ArchiveDocumentTests.swift
@@ -111,6 +111,34 @@ class ArchiveDocumentTests: XCTestCase {
         XCTAssertNil(controller.presentedViewController, "it said the file would not open")
     }
 
+    /// odrcore has no html type, so it reads the page's own source as text. The
+    /// system draws the page, as it did before the reader asked the core.
+    func testHtmlIsLeftToTheSystem() throws {
+        for pathExtension in ["html", "htm", "xhtml"] {
+            try present(try writeHtml(ofType: pathExtension))
+
+            let opened = expectation(description: "opened " + pathExtension)
+            document.open { _ in opened.fulfill() }
+            wait(for: [opened], timeout: 60)
+
+            let shown = try XCTUnwrap(waitForURL { $0.isFileURL }, pathExtension)
+
+            XCTAssertEqual(shown.lastPathComponent, "test." + pathExtension, shown.absoluteString)
+            XCTAssertNil(controller.presentedViewController, "it said the file would not open")
+        }
+    }
+
+    private func writeHtml(ofType pathExtension: String) throws -> URL {
+        let documentsURL = try FileManager.default.url(
+            for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: false)
+
+        let url = documentsURL.appendingPathComponent("test." + pathExtension)
+        try? FileManager.default.removeItem(at: url)
+        try "<html><body><h1>Heading</h1></body></html>".write(to: url, atomically: true, encoding: .utf8)
+
+        return url
+    }
+
     /// And when the system cannot draw it after all, the listing takes over
     /// rather than a message.
     func testAnArchiveTheSystemCannotDrawFallsBackToTheListing() throws {

--- a/OpenDocumentReaderTests/EditWorkflowTests.swift
+++ b/OpenDocumentReaderTests/EditWorkflowTests.swift
@@ -107,7 +107,9 @@ class EditWorkflowTests: XCTestCase {
                 """
                 (function () {
                     var run = document.querySelector('[contenteditable]');
-                    var box = run.getBoundingClientRect();
+                    // not getBoundingClientRect: the view applies a zoom to fit,
+                    // which webkit leaves out of it but elementFromPoint expects
+                    var box = odr.getViewportRect(run);
                     var hit = document.elementFromPoint(box.left + box.width / 2, box.top + box.height / 2);
 
                     return hit ? hit.tagName : 'none';

--- a/OpenDocumentReaderTests/EditWorkflowTests.swift
+++ b/OpenDocumentReaderTests/EditWorkflowTests.swift
@@ -107,9 +107,7 @@ class EditWorkflowTests: XCTestCase {
                 """
                 (function () {
                     var run = document.querySelector('[contenteditable]');
-                    // not getBoundingClientRect: the view applies a zoom to fit,
-                    // which webkit leaves out of it but elementFromPoint expects
-                    var box = odr.getViewportRect(run);
+                    var box = run.getBoundingClientRect();
                     var hit = document.elementFromPoint(box.left + box.width / 2, box.top + box.height / 2);
 
                     return hit ? hit.tagName : 'none';

--- a/OpenDocumentReaderTests/OpenDocumentReaderTests.swift
+++ b/OpenDocumentReaderTests/OpenDocumentReaderTests.swift
@@ -391,6 +391,41 @@ class OpenDocumentReaderTests: XCTestCase {
         XCTAssertEqual(wrapper.pageNames, ["text"])
     }
 
+    /// A text file comes back as `text`; a markdown one as a document, with the
+    /// hashes and stars turned into a heading and a bold run.
+    func testMarkdownIsReadAsProse() throws {
+        let wrapper = CoreWrapper()
+
+        let notes = URL(fileURLWithPath: temporaryDirectory).appendingPathComponent("notes.md")
+        try "# Heading\n\nSome **bold** prose.\n".write(to: notes, atomically: true, encoding: .utf8)
+
+        try wrapper.translate(
+            notes.path, cache: temporaryDirectory, into: temporaryDirectory, with: nil, editable: false)
+
+        XCTAssertEqual(wrapper.pageNames, ["document"])
+
+        let (data, _) = try fetch(try XCTUnwrap(wrapper.pageURLs.first))
+        let html = try XCTUnwrap(String(data: data, encoding: .utf8))
+
+        XCTAssertTrue(html.contains("font-size:2em"), "the heading is not one")
+        XCTAssertTrue(html.contains("font-weight:bold"), "the bold run is not bold")
+        XCTAssertFalse(html.contains("# Heading"), "the hashes are still in it")
+        XCTAssertFalse(html.contains("**bold**"), "the stars are still in it")
+    }
+
+    /// A `.csv` is odrcore's decision from the text; the name must not take it.
+    func testCsvIsStillOdrcoresDecision() throws {
+        let wrapper = CoreWrapper()
+
+        let rows = URL(fileURLWithPath: temporaryDirectory).appendingPathComponent("rows.csv")
+        try "a,b\n1,2\n".write(to: rows, atomically: true, encoding: .utf8)
+
+        try wrapper.translate(
+            rows.path, cache: temporaryDirectory, into: temporaryDirectory, with: nil, editable: false)
+
+        XCTAssertFalse(wrapper.pageNames.isEmpty)
+    }
+
     func testTranslatePerformance() throws {
         let wrapper = CoreWrapper()
         let path = documentURL.path

--- a/fastlane/metadata/de-DE/description.txt
+++ b/fastlane/metadata/de-DE/description.txt
@@ -24,7 +24,7 @@ Darüber hinaus unterstützt der Dokumentenbetrachter viele weitere Dateiformate
 - Bilder: JPG, JPEG, GIF, PNG, WEBP, TIFF, BMP, SVG, etc
 - Videos: MP4, WEBM, etc
 - Audio: MP3, OGG, etc
-- Textdateien: CSV, TXT, MD, RTF
+- Textdateien: CSV, TXT, HTML, MD, RTF
 - Microsoft Office (OOXML): Word (DOC, DOCX), Excel (XLS, XLSX), PowerPoint (PPT, PPTX)
 - Apple iWork: Pages, Numbers, Keynote
 - Libre Office und Open Office ODF (ODT, ODS, ODP, ODG, FODT, FODS, FODP, FODG)

--- a/fastlane/metadata/de-DE/description.txt
+++ b/fastlane/metadata/de-DE/description.txt
@@ -24,7 +24,7 @@ Darüber hinaus unterstützt der Dokumentenbetrachter viele weitere Dateiformate
 - Bilder: JPG, JPEG, GIF, PNG, WEBP, TIFF, BMP, SVG, etc
 - Videos: MP4, WEBM, etc
 - Audio: MP3, OGG, etc
-- Textdateien: CSV, TXT, RTF
+- Textdateien: CSV, TXT, MD, RTF
 - Microsoft Office (OOXML): Word (DOC, DOCX), Excel (XLS, XLSX), PowerPoint (PPT, PPTX)
 - Apple iWork: Pages, Numbers, Keynote
 - Libre Office und Open Office ODF (ODT, ODS, ODP, ODG, FODT, FODS, FODP, FODG)

--- a/fastlane/metadata/de-DE/description.txt
+++ b/fastlane/metadata/de-DE/description.txt
@@ -24,13 +24,10 @@ Darüber hinaus unterstützt der Dokumentenbetrachter viele weitere Dateiformate
 - Bilder: JPG, JPEG, GIF, PNG, WEBP, TIFF, BMP, SVG, etc
 - Videos: MP4, WEBM, etc
 - Audio: MP3, OGG, etc
-- Textdateien: CSV, TXT, HTML, RTF
+- Textdateien: CSV, TXT, RTF
 - Microsoft Office (OOXML): Word (DOC, DOCX), Excel (XLS, XLSX), PowerPoint (PPT, PPTX)
 - Apple iWork: Pages, Numbers, Keynote
-- Libre Office und Open Office ODF (ODT, ODS, ODP, ODG)
-- PostScript (EPS)
-- AutoCAD (DXF)
-- Photoshop (PSD)
+- Libre Office und Open Office ODF (ODT, ODS, ODP, ODG, FODT, FODS, FODP, FODG)
 
 Diese App ist Open Source. Wir stehen in keiner Verbindung zu OpenOffice, LibreOffice oder ähnlichen Projekten. Made in Austria. ${ads} Über Rückmeldungen jeder Art per E-Mail freuen wir uns sehr.
 

--- a/fastlane/metadata/en-US/description.txt
+++ b/fastlane/metadata/en-US/description.txt
@@ -24,13 +24,10 @@ In addition to that, the document reader aims to support various other file form
 - Images: JPG, JPEG, GIF, PNG, WEBP, TIFF, BMP, SVG, etc
 - Videos: MP4, WEBM, etc
 - Audio: MP3, OGG, etc
-- Text files: CSV, TXT, HTML, RTF
+- Text files: CSV, TXT, RTF
 - Microsoft Office (OOXML): Word (DOC, DOCX), Excel (XLS, XLSX), PowerPoint (PPT, PPTX)
 - Apple iWork: Pages, Numbers, Keynote
-- Libre Office and Open Office ODF (ODT, ODS, ODP, ODG)
-- PostScript (EPS)
-- AutoCAD (DXF)
-- Photoshop (PSD)
+- Libre Office and Open Office ODF (ODT, ODS, ODP, ODG, FODT, FODS, FODP, FODG)
 
 This app is open source. We are not affiliated with OpenOffice, LibreOffice or similar. Made in Austria. ${ads} We highly appreciate all kinds of feedback via email.
 

--- a/fastlane/metadata/en-US/description.txt
+++ b/fastlane/metadata/en-US/description.txt
@@ -24,7 +24,7 @@ In addition to that, the document reader aims to support various other file form
 - Images: JPG, JPEG, GIF, PNG, WEBP, TIFF, BMP, SVG, etc
 - Videos: MP4, WEBM, etc
 - Audio: MP3, OGG, etc
-- Text files: CSV, TXT, RTF
+- Text files: CSV, TXT, MD, RTF
 - Microsoft Office (OOXML): Word (DOC, DOCX), Excel (XLS, XLSX), PowerPoint (PPT, PPTX)
 - Apple iWork: Pages, Numbers, Keynote
 - Libre Office and Open Office ODF (ODT, ODS, ODP, ODG, FODT, FODS, FODP, FODG)

--- a/fastlane/metadata/en-US/description.txt
+++ b/fastlane/metadata/en-US/description.txt
@@ -24,7 +24,7 @@ In addition to that, the document reader aims to support various other file form
 - Images: JPG, JPEG, GIF, PNG, WEBP, TIFF, BMP, SVG, etc
 - Videos: MP4, WEBM, etc
 - Audio: MP3, OGG, etc
-- Text files: CSV, TXT, MD, RTF
+- Text files: CSV, TXT, HTML, MD, RTF
 - Microsoft Office (OOXML): Word (DOC, DOCX), Excel (XLS, XLSX), PowerPoint (PPT, PPTX)
 - Apple iWork: Pages, Numbers, Keynote
 - Libre Office and Open Office ODF (ODT, ODS, ODP, ODG, FODT, FODS, FODP, FODG)

--- a/fastlane/metadata/es-ES/description.txt
+++ b/fastlane/metadata/es-ES/description.txt
@@ -24,7 +24,7 @@ Además, el lector de documentos procura admitir lo mejor posible muchos otros f
 - Imágenes: JPG, JPEG, GIF, PNG, WEBP, TIFF, BMP, SVG, etc.
 - Vídeos: MP4, WEBM, etc.
 - Audio: MP3, OGG, etc.
-- Archivos de texto: CSV, TXT, MD, RTF
+- Archivos de texto: CSV, TXT, HTML, MD, RTF
 - Microsoft Office (OOXML): Word (DOC, DOCX), Excel (XLS, XLSX), PowerPoint (PPT, PPTX)
 - Apple iWork: Pages, Numbers, Keynote
 - Libre Office y Open Office ODF (ODT, ODS, ODP, ODG, FODT, FODS, FODP, FODG)

--- a/fastlane/metadata/es-ES/description.txt
+++ b/fastlane/metadata/es-ES/description.txt
@@ -24,13 +24,10 @@ Además, el lector de documentos procura admitir lo mejor posible muchos otros f
 - Imágenes: JPG, JPEG, GIF, PNG, WEBP, TIFF, BMP, SVG, etc.
 - Vídeos: MP4, WEBM, etc.
 - Audio: MP3, OGG, etc.
-- Archivos de texto: CSV, TXT, HTML, RTF
+- Archivos de texto: CSV, TXT, RTF
 - Microsoft Office (OOXML): Word (DOC, DOCX), Excel (XLS, XLSX), PowerPoint (PPT, PPTX)
 - Apple iWork: Pages, Numbers, Keynote
-- Libre Office y Open Office ODF (ODT, ODS, ODP, ODG)
-- PostScript (EPS)
-- AutoCAD (DXF)
-- Photoshop (PSD)
+- Libre Office y Open Office ODF (ODT, ODS, ODP, ODG, FODT, FODS, FODP, FODG)
 
 Esta aplicación es de código abierto. No estamos afiliados con OpenOffice, LibreOffice ni programas similares. Desarrollada en Austria. ${ads} Agradecemos muchísimo cualquier comentario por correo electrónico.
 

--- a/fastlane/metadata/es-ES/description.txt
+++ b/fastlane/metadata/es-ES/description.txt
@@ -24,7 +24,7 @@ Además, el lector de documentos procura admitir lo mejor posible muchos otros f
 - Imágenes: JPG, JPEG, GIF, PNG, WEBP, TIFF, BMP, SVG, etc.
 - Vídeos: MP4, WEBM, etc.
 - Audio: MP3, OGG, etc.
-- Archivos de texto: CSV, TXT, RTF
+- Archivos de texto: CSV, TXT, MD, RTF
 - Microsoft Office (OOXML): Word (DOC, DOCX), Excel (XLS, XLSX), PowerPoint (PPT, PPTX)
 - Apple iWork: Pages, Numbers, Keynote
 - Libre Office y Open Office ODF (ODT, ODS, ODP, ODG, FODT, FODS, FODP, FODG)

--- a/fastlane/metadata/fr-FR/description.txt
+++ b/fastlane/metadata/fr-FR/description.txt
@@ -24,7 +24,7 @@ Par ailleurs, la visionneuse de documents a pour objectif de prendre en charge a
 - Images : JPG, JPEG, GIF, PNG, WEBP, TIFF, BMP, SVG, etc
 - Vidéos : MP4, WEBM, etc
 - Audio : MP3, OGG, etc
-- Fichiers texte : CSV, TXT, MD, RTF
+- Fichiers texte : CSV, TXT, HTML, MD, RTF
 - Microsoft Office (OOXML) : Word (DOC, DOCX), Excel (XLS, XLSX), PowerPoint (PPT, PPTX)
 - Apple iWork : Pages, Numbers, Keynote
 - Libre Office et Open Office ODF (ODT, ODS, ODP, ODG, FODT, FODS, FODP, FODG)

--- a/fastlane/metadata/fr-FR/description.txt
+++ b/fastlane/metadata/fr-FR/description.txt
@@ -24,13 +24,10 @@ Par ailleurs, la visionneuse de documents a pour objectif de prendre en charge a
 - Images : JPG, JPEG, GIF, PNG, WEBP, TIFF, BMP, SVG, etc
 - Vidéos : MP4, WEBM, etc
 - Audio : MP3, OGG, etc
-- Fichiers texte : CSV, TXT, HTML, RTF
+- Fichiers texte : CSV, TXT, RTF
 - Microsoft Office (OOXML) : Word (DOC, DOCX), Excel (XLS, XLSX), PowerPoint (PPT, PPTX)
 - Apple iWork : Pages, Numbers, Keynote
-- Libre Office et Open Office ODF (ODT, ODS, ODP, ODG)
-- PostScript (EPS)
-- AutoCAD (DXF)
-- Photoshop (PSD)
+- Libre Office et Open Office ODF (ODT, ODS, ODP, ODG, FODT, FODS, FODP, FODG)
 
 Cette application est open source. Nous ne sommes affiliés ni à OpenOffice, ni à LibreOffice, ni à aucun projet similaire. Fabriquée en Autriche. ${ads} Tous vos retours par e-mail sont les bienvenus.
 

--- a/fastlane/metadata/fr-FR/description.txt
+++ b/fastlane/metadata/fr-FR/description.txt
@@ -24,7 +24,7 @@ Par ailleurs, la visionneuse de documents a pour objectif de prendre en charge a
 - Images : JPG, JPEG, GIF, PNG, WEBP, TIFF, BMP, SVG, etc
 - Vidéos : MP4, WEBM, etc
 - Audio : MP3, OGG, etc
-- Fichiers texte : CSV, TXT, RTF
+- Fichiers texte : CSV, TXT, MD, RTF
 - Microsoft Office (OOXML) : Word (DOC, DOCX), Excel (XLS, XLSX), PowerPoint (PPT, PPTX)
 - Apple iWork : Pages, Numbers, Keynote
 - Libre Office et Open Office ODF (ODT, ODS, ODP, ODG, FODT, FODS, FODP, FODG)

--- a/fastlane/metadata/hi/description.txt
+++ b/fastlane/metadata/hi/description.txt
@@ -24,7 +24,7 @@ LibreOffice या OpenOffice में बनी ODF फाइलें (ODT, O
 - इमेज: JPG, JPEG, GIF, PNG, WEBP, TIFF, BMP, SVG आदि
 - वीडियो: MP4, WEBM आदि
 - ऑडियो: MP3, OGG आदि
-- टेक्स्ट फाइलें: CSV, TXT, MD, RTF
+- टेक्स्ट फाइलें: CSV, TXT, HTML, MD, RTF
 - Microsoft Office (OOXML): Word (DOC, DOCX), Excel (XLS, XLSX), PowerPoint (PPT, PPTX)
 - Apple iWork: Pages, Numbers, Keynote
 - Libre Office और Open Office ODF (ODT, ODS, ODP, ODG, FODT, FODS, FODP, FODG)

--- a/fastlane/metadata/hi/description.txt
+++ b/fastlane/metadata/hi/description.txt
@@ -24,7 +24,7 @@ LibreOffice या OpenOffice में बनी ODF फाइलें (ODT, O
 - इमेज: JPG, JPEG, GIF, PNG, WEBP, TIFF, BMP, SVG आदि
 - वीडियो: MP4, WEBM आदि
 - ऑडियो: MP3, OGG आदि
-- टेक्स्ट फाइलें: CSV, TXT, RTF
+- टेक्स्ट फाइलें: CSV, TXT, MD, RTF
 - Microsoft Office (OOXML): Word (DOC, DOCX), Excel (XLS, XLSX), PowerPoint (PPT, PPTX)
 - Apple iWork: Pages, Numbers, Keynote
 - Libre Office और Open Office ODF (ODT, ODS, ODP, ODG, FODT, FODS, FODP, FODG)

--- a/fastlane/metadata/hi/description.txt
+++ b/fastlane/metadata/hi/description.txt
@@ -24,13 +24,10 @@ LibreOffice या OpenOffice में बनी ODF फाइलें (ODT, O
 - इमेज: JPG, JPEG, GIF, PNG, WEBP, TIFF, BMP, SVG आदि
 - वीडियो: MP4, WEBM आदि
 - ऑडियो: MP3, OGG आदि
-- टेक्स्ट फाइलें: CSV, TXT, HTML, RTF
+- टेक्स्ट फाइलें: CSV, TXT, RTF
 - Microsoft Office (OOXML): Word (DOC, DOCX), Excel (XLS, XLSX), PowerPoint (PPT, PPTX)
 - Apple iWork: Pages, Numbers, Keynote
-- Libre Office और Open Office ODF (ODT, ODS, ODP, ODG)
-- PostScript (EPS)
-- AutoCAD (DXF)
-- Photoshop (PSD)
+- Libre Office और Open Office ODF (ODT, ODS, ODP, ODG, FODT, FODS, FODP, FODG)
 
 यह ऐप ओपन सोर्स है। OpenOffice, LibreOffice या इनसे मिलते-जुलते किसी भी संगठन से हमारा कोई संबंध नहीं है। ऑस्ट्रिया में बना। ${ads} हर तरह की राय ईमेल से भेजें, हमें बहुत अच्छा लगेगा।
 

--- a/fastlane/metadata/it/description.txt
+++ b/fastlane/metadata/it/description.txt
@@ -24,7 +24,7 @@ Oltre a questo, il lettore di documenti punta a supportare al meglio anche molti
 - Immagini: JPG, JPEG, GIF, PNG, WEBP, TIFF, BMP, SVG, ecc.
 - Video: MP4, WEBM, ecc.
 - Audio: MP3, OGG, ecc.
-- File di testo: CSV, TXT, RTF
+- File di testo: CSV, TXT, MD, RTF
 - Microsoft Office (OOXML): Word (DOC, DOCX), Excel (XLS, XLSX), PowerPoint (PPT, PPTX)
 - Apple iWork: Pages, Numbers, Keynote
 - Libre Office e Open Office ODF (ODT, ODS, ODP, ODG, FODT, FODS, FODP, FODG)

--- a/fastlane/metadata/it/description.txt
+++ b/fastlane/metadata/it/description.txt
@@ -24,7 +24,7 @@ Oltre a questo, il lettore di documenti punta a supportare al meglio anche molti
 - Immagini: JPG, JPEG, GIF, PNG, WEBP, TIFF, BMP, SVG, ecc.
 - Video: MP4, WEBM, ecc.
 - Audio: MP3, OGG, ecc.
-- File di testo: CSV, TXT, MD, RTF
+- File di testo: CSV, TXT, HTML, MD, RTF
 - Microsoft Office (OOXML): Word (DOC, DOCX), Excel (XLS, XLSX), PowerPoint (PPT, PPTX)
 - Apple iWork: Pages, Numbers, Keynote
 - Libre Office e Open Office ODF (ODT, ODS, ODP, ODG, FODT, FODS, FODP, FODG)

--- a/fastlane/metadata/it/description.txt
+++ b/fastlane/metadata/it/description.txt
@@ -24,13 +24,10 @@ Oltre a questo, il lettore di documenti punta a supportare al meglio anche molti
 - Immagini: JPG, JPEG, GIF, PNG, WEBP, TIFF, BMP, SVG, ecc.
 - Video: MP4, WEBM, ecc.
 - Audio: MP3, OGG, ecc.
-- File di testo: CSV, TXT, HTML, RTF
+- File di testo: CSV, TXT, RTF
 - Microsoft Office (OOXML): Word (DOC, DOCX), Excel (XLS, XLSX), PowerPoint (PPT, PPTX)
 - Apple iWork: Pages, Numbers, Keynote
-- Libre Office e Open Office ODF (ODT, ODS, ODP, ODG)
-- PostScript (EPS)
-- AutoCAD (DXF)
-- Photoshop (PSD)
+- Libre Office e Open Office ODF (ODT, ODS, ODP, ODG, FODT, FODS, FODP, FODG)
 
 Questa app è open source. Non siamo affiliati a OpenOffice, LibreOffice o simili. Made in Austria. ${ads} Ogni tuo commento via email è sempre benvenuto.
 

--- a/fastlane/metadata/pl/description.txt
+++ b/fastlane/metadata/pl/description.txt
@@ -24,7 +24,7 @@ Poza tym przeglądarka dokumentów stara się jak najlepiej obsługiwać równie
 - Obrazy: JPG, JPEG, GIF, PNG, WEBP, TIFF, BMP, SVG i inne
 - Filmy: MP4, WEBM i inne
 - Dźwięk: MP3, OGG i inne
-- Pliki tekstowe: CSV, TXT, RTF
+- Pliki tekstowe: CSV, TXT, MD, RTF
 - Microsoft Office (OOXML): Word (DOC, DOCX), Excel (XLS, XLSX), PowerPoint (PPT, PPTX)
 - Apple iWork: Pages, Numbers, Keynote
 - Libre Office i Open Office ODF (ODT, ODS, ODP, ODG, FODT, FODS, FODP, FODG)

--- a/fastlane/metadata/pl/description.txt
+++ b/fastlane/metadata/pl/description.txt
@@ -24,7 +24,7 @@ Poza tym przeglądarka dokumentów stara się jak najlepiej obsługiwać równie
 - Obrazy: JPG, JPEG, GIF, PNG, WEBP, TIFF, BMP, SVG i inne
 - Filmy: MP4, WEBM i inne
 - Dźwięk: MP3, OGG i inne
-- Pliki tekstowe: CSV, TXT, MD, RTF
+- Pliki tekstowe: CSV, TXT, HTML, MD, RTF
 - Microsoft Office (OOXML): Word (DOC, DOCX), Excel (XLS, XLSX), PowerPoint (PPT, PPTX)
 - Apple iWork: Pages, Numbers, Keynote
 - Libre Office i Open Office ODF (ODT, ODS, ODP, ODG, FODT, FODS, FODP, FODG)

--- a/fastlane/metadata/pl/description.txt
+++ b/fastlane/metadata/pl/description.txt
@@ -24,13 +24,10 @@ Poza tym przeglądarka dokumentów stara się jak najlepiej obsługiwać równie
 - Obrazy: JPG, JPEG, GIF, PNG, WEBP, TIFF, BMP, SVG i inne
 - Filmy: MP4, WEBM i inne
 - Dźwięk: MP3, OGG i inne
-- Pliki tekstowe: CSV, TXT, HTML, RTF
+- Pliki tekstowe: CSV, TXT, RTF
 - Microsoft Office (OOXML): Word (DOC, DOCX), Excel (XLS, XLSX), PowerPoint (PPT, PPTX)
 - Apple iWork: Pages, Numbers, Keynote
-- Libre Office i Open Office ODF (ODT, ODS, ODP, ODG)
-- PostScript (EPS)
-- AutoCAD (DXF)
-- Photoshop (PSD)
+- Libre Office i Open Office ODF (ODT, ODS, ODP, ODG, FODT, FODS, FODP, FODG)
 
 Ta aplikacja jest oprogramowaniem open source. Nie jesteśmy powiązani z OpenOffice, LibreOffice ani podobnymi projektami. Made in Austria. ${ads} Bardzo cenimy sobie każdą opinię przesłaną e-mailem.
 

--- a/fastlane/metadata/pt-BR/description.txt
+++ b/fastlane/metadata/pt-BR/description.txt
@@ -24,7 +24,7 @@ Além disso, o leitor de documentos procura abrir da melhor forma possível vár
 - Imagens: JPG, JPEG, GIF, PNG, WEBP, TIFF, BMP, SVG etc
 - Vídeos: MP4, WEBM etc
 - Áudio: MP3, OGG etc
-- Arquivos de texto: CSV, TXT, RTF
+- Arquivos de texto: CSV, TXT, MD, RTF
 - Microsoft Office (OOXML): Word (DOC, DOCX), Excel (XLS, XLSX), PowerPoint (PPT, PPTX)
 - Apple iWork: Pages, Numbers, Keynote
 - Libre Office e Open Office ODF (ODT, ODS, ODP, ODG, FODT, FODS, FODP, FODG)

--- a/fastlane/metadata/pt-BR/description.txt
+++ b/fastlane/metadata/pt-BR/description.txt
@@ -24,7 +24,7 @@ Além disso, o leitor de documentos procura abrir da melhor forma possível vár
 - Imagens: JPG, JPEG, GIF, PNG, WEBP, TIFF, BMP, SVG etc
 - Vídeos: MP4, WEBM etc
 - Áudio: MP3, OGG etc
-- Arquivos de texto: CSV, TXT, MD, RTF
+- Arquivos de texto: CSV, TXT, HTML, MD, RTF
 - Microsoft Office (OOXML): Word (DOC, DOCX), Excel (XLS, XLSX), PowerPoint (PPT, PPTX)
 - Apple iWork: Pages, Numbers, Keynote
 - Libre Office e Open Office ODF (ODT, ODS, ODP, ODG, FODT, FODS, FODP, FODG)

--- a/fastlane/metadata/pt-BR/description.txt
+++ b/fastlane/metadata/pt-BR/description.txt
@@ -24,13 +24,10 @@ Além disso, o leitor de documentos procura abrir da melhor forma possível vár
 - Imagens: JPG, JPEG, GIF, PNG, WEBP, TIFF, BMP, SVG etc
 - Vídeos: MP4, WEBM etc
 - Áudio: MP3, OGG etc
-- Arquivos de texto: CSV, TXT, HTML, RTF
+- Arquivos de texto: CSV, TXT, RTF
 - Microsoft Office (OOXML): Word (DOC, DOCX), Excel (XLS, XLSX), PowerPoint (PPT, PPTX)
 - Apple iWork: Pages, Numbers, Keynote
-- Libre Office e Open Office ODF (ODT, ODS, ODP, ODG)
-- PostScript (EPS)
-- AutoCAD (DXF)
-- Photoshop (PSD)
+- Libre Office e Open Office ODF (ODT, ODS, ODP, ODG, FODT, FODS, FODP, FODG)
 
 Este app é de código aberto. Não temos vínculo com o OpenOffice, o LibreOffice ou similares. Feito na Áustria. ${ads} Adoramos receber todo tipo de feedback por e-mail.
 

--- a/fastlane/metadata/ru/description.txt
+++ b/fastlane/metadata/ru/description.txt
@@ -24,7 +24,7 @@
 - Изображения: JPG, JPEG, GIF, PNG, WEBP, TIFF, BMP, SVG и др.
 - Видео: MP4, WEBM и др.
 - Аудио: MP3, OGG и др.
-- Текстовые файлы: CSV, TXT, MD, RTF
+- Текстовые файлы: CSV, TXT, HTML, MD, RTF
 - Microsoft Office (OOXML): Word (DOC, DOCX), Excel (XLS, XLSX), PowerPoint (PPT, PPTX)
 - Apple iWork: Pages, Numbers, Keynote
 - Libre Office и Open Office ODF (ODT, ODS, ODP, ODG, FODT, FODS, FODP, FODG)

--- a/fastlane/metadata/ru/description.txt
+++ b/fastlane/metadata/ru/description.txt
@@ -24,7 +24,7 @@
 - Изображения: JPG, JPEG, GIF, PNG, WEBP, TIFF, BMP, SVG и др.
 - Видео: MP4, WEBM и др.
 - Аудио: MP3, OGG и др.
-- Текстовые файлы: CSV, TXT, RTF
+- Текстовые файлы: CSV, TXT, MD, RTF
 - Microsoft Office (OOXML): Word (DOC, DOCX), Excel (XLS, XLSX), PowerPoint (PPT, PPTX)
 - Apple iWork: Pages, Numbers, Keynote
 - Libre Office и Open Office ODF (ODT, ODS, ODP, ODG, FODT, FODS, FODP, FODG)

--- a/fastlane/metadata/ru/description.txt
+++ b/fastlane/metadata/ru/description.txt
@@ -24,13 +24,10 @@
 - Изображения: JPG, JPEG, GIF, PNG, WEBP, TIFF, BMP, SVG и др.
 - Видео: MP4, WEBM и др.
 - Аудио: MP3, OGG и др.
-- Текстовые файлы: CSV, TXT, HTML, RTF
+- Текстовые файлы: CSV, TXT, RTF
 - Microsoft Office (OOXML): Word (DOC, DOCX), Excel (XLS, XLSX), PowerPoint (PPT, PPTX)
 - Apple iWork: Pages, Numbers, Keynote
-- Libre Office и Open Office ODF (ODT, ODS, ODP, ODG)
-- PostScript (EPS)
-- AutoCAD (DXF)
-- Photoshop (PSD)
+- Libre Office и Open Office ODF (ODT, ODS, ODP, ODG, FODT, FODS, FODP, FODG)
 
 Это приложение с открытым исходным кодом. Мы никак не связаны с OpenOffice, LibreOffice или подобными проектами. Сделано в Австрии. ${ads} Будем рады любым отзывам по электронной почте.
 

--- a/fastlane/metadata/sv/description.txt
+++ b/fastlane/metadata/sv/description.txt
@@ -24,13 +24,10 @@ Dessutom stöder dokumentläsaren så många andra filformat som möjligt:
 - Bilder: JPG, JPEG, GIF, PNG, WEBP, TIFF, BMP, SVG med flera
 - Video: MP4, WEBM med flera
 - Ljud: MP3, OGG med flera
-- Textfiler: CSV, TXT, HTML, RTF
+- Textfiler: CSV, TXT, RTF
 - Microsoft Office (OOXML): Word (DOC, DOCX), Excel (XLS, XLSX), PowerPoint (PPT, PPTX)
 - Apple iWork: Pages, Numbers, Keynote
-- Libre Office och Open Office ODF (ODT, ODS, ODP, ODG)
-- PostScript (EPS)
-- AutoCAD (DXF)
-- Photoshop (PSD)
+- Libre Office och Open Office ODF (ODT, ODS, ODP, ODG, FODT, FODS, FODP, FODG)
 
 Appen är öppen källkod. Vi har ingen koppling till OpenOffice, LibreOffice eller liknande. Tillverkad i Österrike. ${ads} Vi uppskattar all form av återkoppling via e-post.
 

--- a/fastlane/metadata/sv/description.txt
+++ b/fastlane/metadata/sv/description.txt
@@ -24,7 +24,7 @@ Dessutom stöder dokumentläsaren så många andra filformat som möjligt:
 - Bilder: JPG, JPEG, GIF, PNG, WEBP, TIFF, BMP, SVG med flera
 - Video: MP4, WEBM med flera
 - Ljud: MP3, OGG med flera
-- Textfiler: CSV, TXT, RTF
+- Textfiler: CSV, TXT, MD, RTF
 - Microsoft Office (OOXML): Word (DOC, DOCX), Excel (XLS, XLSX), PowerPoint (PPT, PPTX)
 - Apple iWork: Pages, Numbers, Keynote
 - Libre Office och Open Office ODF (ODT, ODS, ODP, ODG, FODT, FODS, FODP, FODG)

--- a/fastlane/metadata/sv/description.txt
+++ b/fastlane/metadata/sv/description.txt
@@ -24,7 +24,7 @@ Dessutom stöder dokumentläsaren så många andra filformat som möjligt:
 - Bilder: JPG, JPEG, GIF, PNG, WEBP, TIFF, BMP, SVG med flera
 - Video: MP4, WEBM med flera
 - Ljud: MP3, OGG med flera
-- Textfiler: CSV, TXT, MD, RTF
+- Textfiler: CSV, TXT, HTML, MD, RTF
 - Microsoft Office (OOXML): Word (DOC, DOCX), Excel (XLS, XLSX), PowerPoint (PPT, PPTX)
 - Apple iWork: Pages, Numbers, Keynote
 - Libre Office och Open Office ODF (ODT, ODS, ODP, ODG, FODT, FODS, FODP, FODG)

--- a/fastlane/metadata/tr/description.txt
+++ b/fastlane/metadata/tr/description.txt
@@ -24,7 +24,7 @@ Bunlara ek olarak belge okuyucu, diğer birçok dosya biçimini de elinden geldi
 - Resimler: JPG, JPEG, GIF, PNG, WEBP, TIFF, BMP, SVG vb.
 - Videolar: MP4, WEBM vb.
 - Ses: MP3, OGG vb.
-- Metin dosyaları: CSV, TXT, MD, RTF
+- Metin dosyaları: CSV, TXT, HTML, MD, RTF
 - Microsoft Office (OOXML): Word (DOC, DOCX), Excel (XLS, XLSX), PowerPoint (PPT, PPTX)
 - Apple iWork: Pages, Numbers, Keynote
 - Libre Office ve Open Office ODF (ODT, ODS, ODP, ODG, FODT, FODS, FODP, FODG)

--- a/fastlane/metadata/tr/description.txt
+++ b/fastlane/metadata/tr/description.txt
@@ -24,13 +24,10 @@ Bunlara ek olarak belge okuyucu, diğer birçok dosya biçimini de elinden geldi
 - Resimler: JPG, JPEG, GIF, PNG, WEBP, TIFF, BMP, SVG vb.
 - Videolar: MP4, WEBM vb.
 - Ses: MP3, OGG vb.
-- Metin dosyaları: CSV, TXT, HTML, RTF
+- Metin dosyaları: CSV, TXT, RTF
 - Microsoft Office (OOXML): Word (DOC, DOCX), Excel (XLS, XLSX), PowerPoint (PPT, PPTX)
 - Apple iWork: Pages, Numbers, Keynote
-- Libre Office ve Open Office ODF (ODT, ODS, ODP, ODG)
-- PostScript (EPS)
-- AutoCAD (DXF)
-- Photoshop (PSD)
+- Libre Office ve Open Office ODF (ODT, ODS, ODP, ODG, FODT, FODS, FODP, FODG)
 
 Bu uygulama açık kaynaklıdır. OpenOffice, LibreOffice veya benzeri programlarla herhangi bir bağlantımız yoktur. Avusturya'da üretilmiştir. ${ads} Her türlü geri bildiriminizi e-posta ile bize iletmenizden memnuniyet duyarız.
 

--- a/fastlane/metadata/tr/description.txt
+++ b/fastlane/metadata/tr/description.txt
@@ -24,7 +24,7 @@ Bunlara ek olarak belge okuyucu, diğer birçok dosya biçimini de elinden geldi
 - Resimler: JPG, JPEG, GIF, PNG, WEBP, TIFF, BMP, SVG vb.
 - Videolar: MP4, WEBM vb.
 - Ses: MP3, OGG vb.
-- Metin dosyaları: CSV, TXT, RTF
+- Metin dosyaları: CSV, TXT, MD, RTF
 - Microsoft Office (OOXML): Word (DOC, DOCX), Excel (XLS, XLSX), PowerPoint (PPT, PPTX)
 - Apple iWork: Pages, Numbers, Keynote
 - Libre Office ve Open Office ODF (ODT, ODS, ODP, ODG, FODT, FODS, FODP, FODG)


### PR DESCRIPTION
odrcore 6.10.1 → 6.11.0, resolved against the tag. The release went out as a minor despite carrying a breaking change.

Paired with opendocument-app/OpenDocument.droid#634.

## Two workarounds come back fixed, one does not

Three were filed from #183. Two go:

| filed | fixed by | what goes here |
| --- | --- | --- |
| core#730 `target="_blank"` on every view | core#756 | the `WKUIDelegate` no longer has to catch served links |
| core#728 the text fallback | core#743 | the charset check in `CoreWrapper.translate` |
| core#706 / core#726 no top-level fit | core#745 | **nothing — see below** |

The charset check was always a workaround for the core answering "text" to anything it did not recognise. Now `decode` throws and `listFileTypes` comes back empty, which the guard three lines above already catches — and it catches the NUL-padded binaries the charset check missed.

The link target needed new code rather than a deletion. Only external links carry `target="_blank"` now, so served links navigate in place and never reach `createWebViewWith`; what does reach it is the web, which went nowhere before and now goes to the browser.

### The fit stays ours

`viewportMode = .fitWidthByView` was the headline of this PR and it is reverted. Driving both builds in a simulator, it makes an ODT render **worse** than today: the mode pins `initial-scale=1.0` and leaves the fit to a script inside the view, and in WKWebView that script's zoom never lands, so the page sits at actual size with body text at ~2× and only its first third on screen.

| ODT, portrait | differing pixels vs the shipping build |
| --- | --- |
| with `fitWidthByView` | 11.4% |
| with it off, nothing else changed | 1.2% |

So the user script stays. Filed as opendocument-app/OpenDocument.core#761 with the emitted viewport for each mode.

Worth recording from the same run: on iOS 26 WKWebView fits a top-level page by itself at load, so in portrait the script is no longer doing anything. It is still needed on **rotation** — without it, turning the phone leaves the document at the old scale (9% of pixels differ). That is the half `fit_width_by_view` was meant to take over.

## Picked up from Android

**The spreadsheet limits** are stated rather than inherited, the same numbers as droid#623 and droid#634: 100000 × 500 with a 500000-cell budget. Without this the bump silently moves them, since core#757 raised the default from 10000 rows and added the budget.

The apple binding makes this awkward: `spreadsheetLimit` is a `TableDimensions` boxed in an `NSValue`, and Swift has no `@encode`, so the type encoding is a string literal. Filed as opendocument-app/OpenDocument.core#759.

**HTML** is drawn by the system again. odrcore has no html type, so an `.html` decoded as text and the reader showed the page's source; `html`, `htm` and `xhtml` were in the extension list #183 replaced with "ask the core", and nothing took over. `systemDrawsItBetter` already means what is wanted, so html joins iWork in it, by type. `public.xhtml` conforms to xml and not to html, so both types are named — xml alone would catch flat ODF, which odrcore does render.

EPS, DXF and PSD stay out of the listing, and a probe says why: a WKWebView answers `canShowMIMEType` **false** for all three (`com.adobe.photoshop-image`, `com.adobe.encapsulated-postscript`, and DXF has no declared type at all). There was never a native rendering behind those three claims.

**Markdown** now opens as prose. It has no signature, so odrcore reads a `.md` as text and only the name can say otherwise; `CoreWrapper.openFile` opens again as the type the name states, under droid's own rule — a document, or a format the core cannot detect from its bytes. Csv is neither and stays the core's decision. This is what a131cf3 held back, so the listing gets its markdown line.

## iWork keeps the system's rendering

odrcore reads `.pages`, `.numbers` and `.key` since core#732/738/739, so they stop being archives and the routing from #183 — it saw a container, the system knows a document — stops firing on its own. But `src/odr/internal/iwork/PLAN.md` has stages 3 and 4, styles and drawables, still open, so a `.pages` renders body text and anchored tables only. That is less than the phone draws, so the three are named explicitly instead.

## Verified

69 tests, 0 failures; `ODR Full`, `ODR Lite` and `ODR Screenshots` all build; format clean. CI green.

Beyond CI, both builds were driven in an iPhone 17 Pro simulator on iOS 26 and photographed portrait → landscape → portrait for the text, sheet, office and pdf screens, then diffed frame for frame against the shipping build. Sheet is identical, pdf differs by 0.8–2% (the pdf fixes), office by 0.7%. That comparison is what found the viewport regression.

Not covered: a real device, and an iPad.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y7ALzy5VB32UfQn263Tbnk
