### PR TITLE
Keep asking for a banner after one does not fill

### DIFF
--- a/Ads/AdSlot.swift
+++ b/Ads/AdSlot.swift
@@ -19,6 +19,23 @@ final class AdSlot: NSObject, BannerViewDelegate {
     /// makes the first request.
     private var requestedWidth: CGFloat?
 
+    /// Whether a banner has ever filled.
+    private var hasAd = false
+
+    /// The pending ask for a slot that did not fill.
+    private var retry: DispatchWorkItem?
+
+    private var retryDelay = AdSlot.firstRetryDelay
+
+    /// 10s, 20s, 40s, then the 60s the unit refreshes at. Not shorter: the sdk throttles a burst
+    /// of failed requests itself.
+    private static let firstRetryDelay: TimeInterval = 10
+    private static let maxRetryDelay: TimeInterval = 60
+
+    deinit {
+        retry?.cancel()
+    }
+
     /// Puts the banner in `slot` and gathers consent. Once per controller: the form is modal, so a
     /// second call on reappearance would bring it back.
     func start(in slot: UIView, from viewController: UIViewController) {
@@ -84,7 +101,31 @@ final class AdSlot: NSObject, BannerViewDelegate {
         requestedWidth = width
 
         bannerView.adSize = currentOrientationAnchoredAdaptiveBanner(width: width)
+
+        retry?.cancel()
+        retryDelay = AdSlot.firstRetryDelay
+
         bannerView.load(Request())
+    }
+
+    /// Asks again for a hidden banner, which the unit will not refresh. Reschedules itself before
+    /// it asks: a request that never comes back must not end the chain. A suspended app cannot
+    /// fire the work item, so backgrounding needs no guard.
+    private func scheduleRetry() {
+        retry?.cancel()
+
+        let work = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+
+            self.retryDelay = min(self.retryDelay * 2, AdSlot.maxRetryDelay)
+            self.scheduleRetry()
+
+            self.bannerView.load(Request())
+        }
+
+        retry = work
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + retryDelay, execute: work)
     }
 
     private func reportNoAd() {
@@ -94,10 +135,20 @@ final class AdSlot: NSObject, BannerViewDelegate {
     }
 
     func bannerView(_ bannerView: BannerView, didFailToReceiveAdWithError error: Error) {
+        CrashManager.shared.log("ad failed to load: \(error.localizedDescription)")
+
+        // the sdk keeps refreshing an ad that is up; only an empty slot needs asking
+        guard !hasAd else { return }
+
         reportNoAd()
+        scheduleRetry()
     }
 
     func bannerViewDidReceiveAd(_ bannerView: BannerView) {
+        retry?.cancel()
+        retryDelay = AdSlot.firstRetryDelay
+        hasAd = true
+
         bannerView.isHidden = false
 
         onAd?()


### PR DESCRIPTION
`didFailToReceiveAdWithError` hid the banner and called `onNoAd`, and nothing asked again for the life of the controller. The ad unit's automatic refresh only runs for a banner that is on screen — a hidden one is not — so **a single refusal left the slot silent until the next document**.

It is the same hole [droid#643](https://github.com/opendocument-app/OpenDocument.droid/pull/643) closes on Android; this is the iOS half.

## What changes

- **A failure schedules its own ask**, rescheduling *before* each request so one that never comes back cannot end the chain and leave the slot as silent as before. The delay doubles up to the rate the unit refreshes at, so a slot that is never going to fill settles on what the sdk would have done anyway. The first ask is not shorter on purpose: the sdk throttles a burst of failed requests itself, and an ask it answers never reaches the auction.
- **A refresh that does not fill keeps the ad already on screen.** Any failure used to hide the banner, including one arriving after a good ad had been served — which forfeited the rest of a live impression and, since a hidden banner is not refreshed, stopped the sdk trying again.
- A failed load leaves a `CrashManager` breadcrumb, as the consent flow already does.

## Notes

- **Backgrounding needs no guard**: a `DispatchWorkItem` cannot fire while the app is suspended, so unlike the Android side this needs no pause/resume plumbing.
- `load()`'s `width != requestedWidth` guard is deliberately bypassed by the retry, which calls `bannerView.load` directly — a retry wants the same width it just failed at.
- The retry is cancelled on a fill, on the next `load()`, and in `deinit`.
- Left alone, and the same on both platforms: a first launch with no network leaves consent undecided and `reportNoAd()` runs with no retry at all. That deserves its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)