### PR TITLE
Stop the phone drawing its own links over a document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ open: **a second build under the same version goes under the already cut
 heading, not back under `Unreleased`.** Date the heading and add its compare link
 once the version tag exists.
 
+## [Unreleased]
+
+### Fixed
+
+- An email address or a date in a PDF no longer has a link drawn over it,
+  which showed the text twice.
+
 ## [1.44]
 
 ### Changed
@@ -283,7 +290,7 @@ submitted.
 - An incorrect password is now reported as such instead of a generic failure.
 - Page handling and decryption fixes when opening protected documents.
 
-[Unreleased]: https://github.com/opendocument-app/OpenDocument.ios/compare/v1.43...HEAD
+[Unreleased]: https://github.com/opendocument-app/OpenDocument.ios/compare/v1.44...HEAD
 [1.43]: https://github.com/opendocument-app/OpenDocument.ios/compare/v1.42...v1.43
 [1.42]: https://github.com/opendocument-app/OpenDocument.ios/compare/v1.41...v1.42
 [1.41]: https://github.com/opendocument-app/OpenDocument.ios/compare/v1.40...v1.41

--- a/OpenDocumentReader/DocumentWebView.swift
+++ b/OpenDocumentReader/DocumentWebView.swift
@@ -1,0 +1,29 @@
+import WebKit
+
+/// The reader's web view, built with a configuration the app states rather than
+/// the one a storyboard hands it.
+///
+/// A `WKWebViewConfiguration` decoded from a nib arrives with every data
+/// detector switched on, and `WKWebView.configuration` returns a copy — so a
+/// configuration is only ever settable here, before `super.init`.
+///
+/// Detectors have to be off. odrcore lays an invisible text layer over a pdf's
+/// glyphs for selection and search; iOS finds an address or a date in it, wraps
+/// it in a link, and the link's own colour paints that layer over the page the
+/// reader is meant to be looking at.
+///
+/// Nothing the storyboard states about this view is lost by not decoding it:
+/// `DocumentViewController` sizes and positions it in code. Its
+/// `wkWebViewConfiguration` element stays there and inert — Interface Builder
+/// fails to compile the storyboard without one.
+final class DocumentWebView: WKWebView {
+
+    required init?(coder: NSCoder) {
+        let configuration = WKWebViewConfiguration()
+        configuration.dataDetectorTypes = []
+        // as the storyboard had it: a document's own media plays without a tap
+        configuration.mediaTypesRequiringUserActionForPlayback = []
+
+        super.init(frame: .zero, configuration: configuration)
+    }
+}

--- a/OpenDocumentReader/DocumentWebView.swift
+++ b/OpenDocumentReader/DocumentWebView.swift
@@ -1,27 +1,13 @@
 import WebKit
 
-/// The reader's web view, built with a configuration the app states rather than
-/// the one a storyboard hands it.
-///
-/// A `WKWebViewConfiguration` decoded from a nib arrives with every data
-/// detector switched on, and `WKWebView.configuration` returns a copy — so a
-/// configuration is only ever settable here, before `super.init`.
-///
-/// Detectors have to be off. odrcore lays an invisible text layer over a pdf's
-/// glyphs for selection and search; iOS finds an address or a date in it, wraps
-/// it in a link, and the link's own colour paints that layer over the page the
-/// reader is meant to be looking at.
-///
-/// Nothing the storyboard states about this view is lost by not decoding it:
-/// `DocumentViewController` sizes and positions it in code. Its
-/// `wkWebViewConfiguration` element stays there and inert — Interface Builder
-/// fails to compile the storyboard without one.
+/// Built here rather than decoded: a nib turns every data detector on, and a
+/// configuration cannot be changed once the view has it. Detectors draw links
+/// over the invisible text a pdf carries for selection and search.
 final class DocumentWebView: WKWebView {
 
     required init?(coder: NSCoder) {
         let configuration = WKWebViewConfiguration()
         configuration.dataDetectorTypes = []
-        // as the storyboard had it: a document's own media plays without a tap
         configuration.mediaTypesRequiringUserActionForPlayback = []
 
         super.init(frame: .zero, configuration: configuration)

--- a/OpenDocumentReader/Main.storyboard
+++ b/OpenDocumentReader/Main.storyboard
@@ -69,7 +69,7 @@
                                     </progressView>
                                 </subviews>
                             </stackView>
-                            <wkWebView contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="VF5-Do-xh9">
+                            <wkWebView contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="VF5-Do-xh9" customClass="DocumentWebView" customModule="OpenDocumentReader" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="190" width="414" height="706"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <color key="backgroundColor" red="0.36078431370000003" green="0.38823529410000002" blue="0.4039215686" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>


### PR DESCRIPTION
A PDF invoice showed its recipient's email address twice, the second copy blue and struck through. The engine was cleared of it: the same file renders correctly from odrcore's own HTML everywhere else.

iOS was drawing that. A `WKWebViewConfiguration` decoded from a storyboard arrives with all seven data detectors on rather than the API default of none — I logged `127` at runtime. The reader lays an invisible copy of a PDF's text over the page so it can be selected and searched, iOS finds an address in that copy and wraps it in a link, and the link's own colour paints the hidden text on top of the page.

`WKWebView.configuration` returns a copy, so the only place a configuration can be set is before `super.init`. Hence the subclass. Nothing about layout moves: `DocumentViewController` already sizes and positions the view in code, so the geometry the subclass skips decoding was never used.

Two other routes were tried and rejected: assigning `dataDetectorTypes` after init does nothing, and neither does a user-defined runtime attribute on the storyboard's configuration. A `format-detection` meta tag injected into the page did work, but it can only name four of the seven detector types.

The storyboard keeps its now-inert `wkWebViewConfiguration` element because Interface Builder fails to compile the file without one.

## Checks

Driven in a simulator against the invoice, counting pixels rather than eyeballing:

- Before: the artefact sits at `y 751-760, x 498-596`, alongside the PDF's genuine "Online bezahlen" link at `y 873-890, x 82-212`.
- After: the artefact is gone and the genuine link is untouched.

Also opened the ODT, ODS and DOCX samples plus the document browser with search running, and built and launched the Lite target to confirm the custom class resolves in both.

## Note

`Unreleased` had no heading and its compare link still pointed at v1.43, so this adds the heading and moves the link to v1.44.

Left open: on the same screenshot the table header row renders about 2.7x too large. This does not fix that, and I could not reproduce it on any simulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)